### PR TITLE
feat: /repair + /silent-save endpoints, cold-start warmup, minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ mempalace.yaml
 entities.json
 *.log
 .env
+venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [1.5.1] - 2026-04-25
+
+### Added
+- **`/search` and `/context` accept `kind=` query param** mirroring the `mempalace_search` MCP tool's input_schema enum. Three values: `content` (default, excludes Stop-hook auto-save checkpoints), `checkpoint` (only checkpoints, recovery/audit), `all` (no filter, pre-2026-04-25 behavior). Backed by jphein/mempalace commit `8d02835`'s read-side filter. End-to-end validated against the 151K-drawer canonical palace: same query returned 5 CHECKPOINT-shaped diary entries with `kind=all` vs. 5 substantive content drawers with `kind=content`. Invalid values return 400.
+- **`_canonical_topic()` helper** in `_silent_save_write`. Rewrites legacy synonyms (currently `"auto-save"` → `"checkpoint"`) at the daemon boundary with a warning log line, so client-side topic drift can't silently leak into palace metadata. Defense-in-depth on top of the per-client canonical-topic constants in `clients/hook.py` and `clients/mempal-fast.py`.
+- **`scripts/verify-routes.sh`** — curl-based smoke test that exercises every public route post-deploy. Designed for manual `systemctl --user restart palace-daemon` validation, not CI (depends on a live palace).
+
+### Fixed
+- **`/search` and `/context` now actually honor `limit=`.** Earlier versions passed `max_results` to the `mempalace_search` MCP tool, but the tool's input_schema declares `limit` — `mempalace.mcp_server.handle_request` then silently dropped the unknown key via its schema-property whitelist (line 1677), and *every* response was capped at the default 5 regardless of what the user asked for. Confirmed against running v1.5.0. Renamed to `limit` so the user-supplied value actually binds.
+
+### Notes
+- The `/search` filter is a daemon-side wrapper around the read-side filter that lives in `mempalace.searcher`. It works because the daemon imports the fork's mempalace at `/mnt/raid/projects/memorypalace`. Upstream MemPalace doesn't have the `kind=` parameter on `mempalace_search` yet — fork PR pending. Until that lands, this daemon needs the fork checked out as its mempalace install.
+
 ## [1.5.0] - 2026-04-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.5.0] - 2026-04-24
+
+### Added
+- **`POST /repair`** — coordinates repairs with daemon-mediated traffic. Four modes:
+  - `light` — clears client/collection caches; next open re-runs `quarantine_stale_hnsw()`. Cheap, non-blocking for other callers.
+  - `scan` — runs `mempalace.repair.scan_palace` under a read slot, returns the count of corrupt IDs found.
+  - `prune` — runs `mempalace.repair.prune_corrupt` under a write slot; the cross-process flock in `ChromaCollection` already serializes this against live writers.
+  - `rebuild` — destructive collection swap (`delete_collection` + `create_collection` are *outside* the flock, so a naked rebuild concurrent with any writer silently loses writes). Holds every read/write/mine semaphore slot during the rebuild window to prevent daemon-mediated writes from racing the swap.
+- **`POST /silent-save`** — HTTP path for Claude Code Stop-hook silent saves. Normal ops: writes a diary checkpoint via `tool_diary_write` under the write semaphore. During `/repair mode=rebuild`: appends the payload to `<palace_parent>/palace-daemon-pending.jsonl` and returns a themed "held in trust" message. The queue drains automatically once the rebuild completes.
+- **`GET /repair/status`** — current repair state + pending-writes queue depth.
+- **Themed messages** — `messages.py` centralizes user-facing strings for save, save-queued, repair-begin, repair-complete, and drain-fail paths. Saves use `✦`; palace ops use `◈`.
+
+### Notes
+- The rebuild coordination is daemon-scoped: external `mempalace repair rebuild` CLI invocations still race against any other process's writes because `delete_collection` / `create_collection` are backend-level operations that the `ChromaCollection` flock does not protect. For safe concurrent rebuilds, route through the daemon.
+- Fork's `mempalace/hooks_cli.py` opt-in: set `PALACE_DAEMON_URL` (and optionally `PALACE_API_KEY`) and silent Stop-hook saves will POST to the daemon, picking up the queue-and-drain behavior and themed messages. Unset or unreachable → falls through to the legacy direct-write path with no behavior change.
+
 ## [1.4.2] - 2026-04-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.6.0] - 2026-04-25
+
+### Added
+- **`GET /graph`** — single-shot structural snapshot for SME-style consumers. Mirrors `/stats`'s `asyncio.gather` shape but adds a parallel `mempalace_list_rooms` fan-out per wing and a direct read-only sqlite read of `knowledge_graph.sqlite3`. Replaces what an adapter would otherwise compose serially over HTTP — on the 151K-drawer canonical palace `list_wings` alone takes ~30s, so a serial composition costs minutes.
+- Response shape: `{ "wings": {...}, "rooms": [{"wing", "rooms"}], "tunnels": [...], "kg_entities": [...], "kg_triples": [...], "kg_stats": {...} }`.
+- KG read uses URI-mode `?mode=ro` so the daemon can never accidentally write that file. Schema differences across mempalace versions tolerated via per-query `OperationalError` catch.
+- Added `GET /graph` probe to `scripts/verify-routes.sh`.
+
+### Notes
+- Spec: `docs/graph-endpoint.md`. Coordinates with `multipass-structural-memory-eval` (SME) — adapter prefers `/graph` once daemon ≥ 1.6.0 and falls back to MCP composition otherwise.
+- `_kg_path()` derives KG location from `_mp._config.palace_path` (sibling to `chroma.sqlite3`), so non-default deployments (`PALACE_PATH=/mnt/raid/...`) work unchanged.
+
 ## [1.5.1] - 2026-04-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -114,11 +114,25 @@ The `-` prefix means failures are ignored (i.e. if nothing is blocking, these ar
 | GET | /repair/status | Current repair state + pending-writes queue depth |
 | POST | /silent-save | Stop-hook silent save; queues during `/repair mode=rebuild` |
 | GET | /stats | Wing/room counts, KG stats |
-| GET | /search?q=...&limit=5 | Semantic search |
-| GET | /context?topic=... | Same as search, named for LLM use |
+| GET | /search?q=...&limit=5&kind=content | Semantic search. `kind` ∈ {content, checkpoint, all} — see below. |
+| GET | /context?topic=...&kind=content | Same as search, named for LLM use |
 | POST | /memory | Store a drawer {content, wing, room} |
 | POST | /mcp | Full MCP JSON-RPC proxy |
 | POST | /mine | Bulk import under lock |
+
+### /search — `kind=` filter (v1.5.1+)
+
+The `kind` query param controls what shape of drawer the daemon returns. It mirrors the `kind` parameter on jphein/mempalace's `mempalace_search` MCP tool (fork commit `8d02835`).
+
+| Value | Returns | When to use |
+|---|---|---|
+| `content` (default) | Substantive drawers; excludes Stop-hook auto-save checkpoints | Almost always — the right answer for retrieval-then-grounding |
+| `checkpoint` | Only Stop-hook checkpoints | Session recovery, hook debugging, audit |
+| `all` | No filter | When you genuinely need every drawer (rare; pre-2026-04-25 behavior) |
+
+Why default to excluding checkpoints? Stop-hook diary entries (`topic=checkpoint`, text starting `"CHECKPOINT:"`) are short word-dense session summaries that consistently outrank substantive content under cosine similarity — by drawer count they're a small fraction of the corpus, but they routinely make up 80%+ of search results. Validated 2026-04-25 on a 151K-drawer palace: same query returned 5 CHECKPOINTs with `kind=all` vs. 5 substantive content drawers with `kind=content`.
+
+Invalid values return `400 Bad Request`. The daemon also canonicalizes the `topic` field at `/silent-save`: legacy synonyms like `"auto-save"` are rewritten to `"checkpoint"` so the read-side filter works regardless of which client wrote the entry.
 
 ### /mine — bulk import
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ The `-` prefix means failures are ignored (i.e. if nothing is blocking, these ar
 | GET | /health | Daemon + palace status (inc. version) |
 | POST | /backup | Atomic verified SQLite backup |
 | POST | /reload | Clear client cache / refresh index |
+| POST | /repair | Coordinate repair with daemon traffic (`mode`: `light`/`scan`/`prune`/`rebuild`) |
+| GET | /repair/status | Current repair state + pending-writes queue depth |
+| POST | /silent-save | Stop-hook silent save; queues during `/repair mode=rebuild` |
 | GET | /stats | Wing/room counts, KG stats |
 | GET | /search?q=...&limit=5 | Semantic search |
 | GET | /context?topic=... | Same as search, named for LLM use |
@@ -126,6 +129,59 @@ The `-` prefix means failures are ignored (i.e. if nothing is blocking, these ar
 Body: dir (required), wing, mode (projects/convos), extract (exchange/general), limit.
 
 Mine jobs run one at a time under their own semaphore. Read and write traffic continues unblocked during a mine job.
+
+### /repair — coordinate a repair
+
+    curl -X POST http://localhost:8085/repair \
+      -H 'Content-Type: application/json' \
+      -d '{"mode": "rebuild"}'
+
+Modes:
+
+- **`light`** — clear cached client/collection; next open re-runs `quarantine_stale_hnsw()`. Fast, non-blocking for other endpoints.
+- **`scan`** — read-only inspection. Runs `mempalace.repair.scan_palace`, writes `corrupt_ids.txt` next to the palace, returns the count.
+- **`prune`** — deletes corrupt IDs via `col.delete()`. The in-library flock (`_palace_write_lock`) already serializes this against concurrent writers.
+- **`rebuild`** — destructive: `delete_collection` + `create_collection`. Those backend-level ops are **outside** the `ChromaCollection` flock, so a rebuild racing a concurrent writer silently drops writes. `/repair mode=rebuild` holds every read/write/mine semaphore slot for the rebuild window, and `/silent-save` callers queue to `<palace_parent>/palace-daemon-pending.jsonl` during this window. The queue drains automatically when the rebuild completes.
+
+Only one repair at a time. A second `/repair` call while one is in-flight returns 409.
+
+Check progress with:
+
+    curl http://localhost:8085/repair/status
+
+### /silent-save — Stop-hook save path
+
+    curl -X POST http://localhost:8085/silent-save \
+      -H 'Content-Type: application/json' \
+      -d '{
+        "session_id": "abc-123",
+        "wing": "wing_myproject",
+        "entry": "CHECKPOINT:2026-04-24|session:abc|msgs:15|recent:...",
+        "themes": ["design", "retrieval"],
+        "message_count": 15
+      }'
+
+Normal response (palace is healthy):
+
+    { "count": 15, "themes": [...], "queued": false,
+      "entry_id": "drawer_xyz",
+      "systemMessage": "✦ 15 memories woven into the palace — design, retrieval" }
+
+During `/repair mode=rebuild`:
+
+    { "count": 15, "themes": [...], "queued": true,
+      "systemMessage": "✦ 15 memories held in trust — the palace is being mended" }
+
+The `systemMessage` field is what Claude Code will render in the terminal when the hook returns it as its `systemMessage` output.
+
+#### Wiring Claude Code hooks through the daemon
+
+To have Stop-hook silent saves go through the daemon (queue-safe during repair, themed messages), set `PALACE_DAEMON_URL` (and `PALACE_API_KEY` if auth is on) in the environment the hook runs under. The fork's `mempalace/hooks_cli.py` detects these, POSTs to `/silent-save`, and emits the daemon's `systemMessage`. If the env var isn't set, or the daemon is unreachable, the hook falls through to the legacy direct-write path — no save is ever lost because the daemon happens to be down.
+
+Example env for the hook invocation (in Claude Code hooks config, or upstream of it):
+
+    PALACE_DAEMON_URL=http://localhost:8085
+    PALACE_API_KEY=your-secret     # optional, only if auth is on
 
 ### Auth
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The `-` prefix means failures are ignored (i.e. if nothing is blocking, these ar
 | POST | /repair | Coordinate repair with daemon traffic (`mode`: `light`/`scan`/`prune`/`rebuild`) |
 | GET | /repair/status | Current repair state + pending-writes queue depth |
 | POST | /silent-save | Stop-hook silent save; queues during `/repair mode=rebuild` |
-| GET | /stats | Wing/room counts, KG stats |
+| GET | /stats | Wing/room counts, KG stats. **Heavy call** — fan-outs to three MCP tools and walks the full corpus; expect 30-90s on a 100K+ drawer palace. Designed for admin / debugging, not chat-turn paths. |
 | GET | /search?q=...&limit=5&kind=content | Semantic search. `kind` ∈ {content, checkpoint, all} — see below. |
 | GET | /context?topic=...&kind=content | Same as search, named for LLM use |
 | POST | /memory | Store a drawer {content, wing, room} |

--- a/clients/hook.py
+++ b/clients/hook.py
@@ -34,6 +34,13 @@ SAVE_INTERVAL = 15
 STATE_DIR = Path.home() / ".mempalace" / "hook_state"
 HOOK_SETTINGS_PATH = Path.home() / ".mempalace" / "hook_settings.json"
 
+# Canonical topic name for Stop-hook auto-save checkpoint diary entries.
+# Defined as a constant so all hook code paths agree on the string value
+# used downstream by mempalace.searcher.build_where_filter for kind=
+# filtering (jphein/mempalace fork-ahead row 21, 2026-04-25). Keep in
+# sync with mempal-fast.py and mempalace.hooks_cli.
+CHECKPOINT_TOPIC = "checkpoint"
+
 SUPPORTED_HARNESSES = {"claude-code", "codex", "gemini-cli"}
 
 STOP_BLOCK_REASON = (
@@ -285,7 +292,7 @@ def hook_stop(data: dict, harness: str):
         ok = _post_mcp(daemon_url, "mempalace_diary_write", {
             "agent_name": harness,
             "entry": entry,
-            "topic": "auto-save",
+            "topic": CHECKPOINT_TOPIC,
         })
         _log(f"Silent save {'OK' if ok else 'FAILED (daemon unreachable)'} at exchange {exchange_count}")
         if toast:

--- a/clients/mempal-fast.py
+++ b/clients/mempal-fast.py
@@ -7,6 +7,12 @@ from pathlib import Path
 SAVE_INTERVAL = 15
 STATE_DIR = Path.home() / ".mempalace" / "hook_state"
 
+# Canonical topic name for Stop-hook auto-save checkpoint diary entries.
+# All hook clients (this fast-path, hook.py, mempalace.hooks_cli) must
+# write the same value so jphein/mempalace's search kind= filter
+# (default kind="content") cleanly excludes them.
+CHECKPOINT_TOPIC = "checkpoint"
+
 
 def log(msg):
     try:
@@ -91,7 +97,7 @@ def main():
         "session_id": session_id,
         "wing": wing_from_path(transcript_path),
         "entry": f"Stop checkpoint at {count} exchanges",
-        "topic": "checkpoint",
+        "topic": CHECKPOINT_TOPIC,
         "agent_name": "session-hook",
         "themes": [],
         "message_count": since_last,

--- a/clients/mempal-fast.py
+++ b/clients/mempal-fast.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# Stdlib-only stop hook — bypasses mempalace import to avoid chromadb HNSW
+# cold-start segfaults. Requires PALACE_DAEMON_URL set.
+import json, os, re, sys, urllib.request
+from pathlib import Path
+
+SAVE_INTERVAL = 15
+STATE_DIR = Path.home() / ".mempalace" / "hook_state"
+
+
+def log(msg):
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        with (STATE_DIR / "hook.log").open("a") as f:
+            from datetime import datetime
+            f.write(f"[{datetime.now().strftime('%H:%M:%S')}] {msg}\n")
+    except OSError:
+        pass
+
+
+def count_human_messages(transcript_path):
+    if not transcript_path:
+        return 0
+    p = Path(transcript_path).expanduser()
+    if not p.is_file() or p.suffix not in (".jsonl", ".json"):
+        return 0
+    n = 0
+    try:
+        with p.open(encoding="utf-8", errors="replace") as f:
+            for line in f:
+                try:
+                    e = json.loads(line)
+                    msg = e.get("message", {})
+                    if isinstance(msg, dict) and msg.get("role") == "user":
+                        c = msg.get("content", "")
+                        text = c if isinstance(c, str) else " ".join(b.get("text", "") for b in c if isinstance(b, dict))
+                        if "<command-message>" not in text:
+                            n += 1
+                except (json.JSONDecodeError, AttributeError):
+                    pass
+    except OSError:
+        pass
+    return n
+
+
+def wing_from_path(transcript_path):
+    if not transcript_path:
+        return "unknown"
+    parts = Path(transcript_path).parts
+    for i, part in enumerate(parts):
+        if part == "projects" and i + 1 < len(parts):
+            return re.sub(r"[^a-zA-Z0-9_-]", "_", parts[i + 1]) or "unknown"
+    return "unknown"
+
+
+def main():
+    hook_type = sys.argv[1] if len(sys.argv) > 1 else "stop"
+    raw = sys.stdin.read()
+    data = json.loads(raw) if raw.strip() else {}
+
+    session_id = re.sub(r"[^a-zA-Z0-9_-]", "", data.get("session_id", "") or "") or "unknown"
+    transcript_path = data.get("transcript_path", "")
+
+    count = count_human_messages(transcript_path)
+    last_save_file = STATE_DIR / f"{session_id}_last_save"
+    try:
+        last_save = int(last_save_file.read_text().strip()) if last_save_file.is_file() else 0
+    except (ValueError, OSError):
+        last_save = 0
+
+    since_last = count - last_save
+    log(f"Session {session_id}: {count} exchanges, {since_last} since last save (fast-path/{hook_type})")
+
+    # Stop hooks gate on threshold; precompact always saves (compaction is imminent).
+    if hook_type == "stop" and (since_last < SAVE_INTERVAL or count <= 0):
+        print("{}")
+        return
+    if hook_type == "precompact" and count <= 0:
+        print("{}")
+        return
+
+    log(f"TRIGGERING SAVE at exchange {count} (fast-path)")
+
+    daemon_url = os.environ.get("PALACE_DAEMON_URL", "").strip().rstrip("/")
+    if not daemon_url:
+        log("ERROR: fast-path called without PALACE_DAEMON_URL")
+        print("{}")
+        return
+
+    payload = {
+        "session_id": session_id,
+        "wing": wing_from_path(transcript_path),
+        "entry": f"Stop checkpoint at {count} exchanges",
+        "topic": "checkpoint",
+        "agent_name": "session-hook",
+        "themes": [],
+        "message_count": since_last,
+    }
+    req = urllib.request.Request(
+        f"{daemon_url}/silent-save",
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"content-type": "application/json"},
+        method="POST",
+    )
+    api_key = os.environ.get("PALACE_API_KEY", "").strip()
+    if api_key:
+        req.add_header("x-api-key", api_key)
+
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            result = json.loads(resp.read().decode("utf-8"))
+        log(f"Daemon silent-save: queued={result.get('queued')} count={result.get('count')} (fast-path)")
+        try:
+            last_save_file.write_text(str(count))
+        except OSError:
+            pass
+        print(json.dumps({"systemMessage": result.get("systemMessage", "")}))
+    except Exception as e:
+        log(f"Daemon silent-save failed (fast-path): {e}")
+        print("{}")
+
+
+if __name__ == "__main__":
+    main()

--- a/clients/mempalace-mcp.py
+++ b/clients/mempalace-mcp.py
@@ -52,7 +52,11 @@ def forward(url: str, request: dict) -> dict:
         headers=headers,
         method="POST",
     )
-    with urllib.request.urlopen(req, timeout=30) as resp:
+    # 120s headroom for slow read tools (e.g. mempalace_status walking a
+    # multi-GB palace) plus short waits behind in-flight writes on the
+    # daemon's read semaphore. Override with PALACE_MCP_TIMEOUT for tuning.
+    timeout = int(os.getenv("PALACE_MCP_TIMEOUT", "120"))
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
         return json.loads(resp.read())
 
 

--- a/clients/mempalace-mcp.py
+++ b/clients/mempalace-mcp.py
@@ -55,7 +55,16 @@ def forward(url: str, request: dict) -> dict:
     # 120s headroom for slow read tools (e.g. mempalace_status walking a
     # multi-GB palace) plus short waits behind in-flight writes on the
     # daemon's read semaphore. Override with PALACE_MCP_TIMEOUT for tuning.
-    timeout = int(os.getenv("PALACE_MCP_TIMEOUT", "120"))
+    raw_timeout = os.getenv("PALACE_MCP_TIMEOUT", "120")
+    try:
+        timeout = int(raw_timeout)
+    except ValueError:
+        print(
+            f"warning: PALACE_MCP_TIMEOUT='{raw_timeout}' is not an integer; "
+            "falling back to 120s",
+            file=sys.stderr,
+        )
+        timeout = 120
     with urllib.request.urlopen(req, timeout=timeout) as resp:
         return json.loads(resp.read())
 

--- a/clients/palace-mcp-dispatch.sh
+++ b/clients/palace-mcp-dispatch.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Dispatches MCP server based on PALACE_DAEMON_URL env var.
+#   set    → proxy to daemon (mempalace-mcp.py)
+#   unset  → in-process mempalace.mcp_server (local palace)
+
+PYTHON="${MEMPALACE_PYTHON:-python3}"
+
+if [ -n "$PALACE_DAEMON_URL" ]; then
+  exec "$PYTHON" /home/jp/Projects/palace-daemon/clients/mempalace-mcp.py --daemon "$PALACE_DAEMON_URL"
+else
+  exec "$PYTHON" -m mempalace.mcp_server
+fi

--- a/clients/palace-mode
+++ b/clients/palace-mode
@@ -7,6 +7,11 @@
 #   palace-mode remote [URL]    # switch hooks/MCP to daemon (default URL)
 #   palace-mode install         # re-apply all customizations (run after plugin updates)
 #   palace-mode verify          # check that all customizations are in place
+#
+# Scope: this tool installs customizations into the Claude Code plugin
+# cache only (~/.claude/plugins/cache/mempalace/...). It deliberately does
+# not modify any plugin source/dev clone the user might have under
+# ~/Projects/, so git status on those clones stays clean.
 
 set -euo pipefail
 
@@ -21,7 +26,6 @@ FAST="$CLIENTS_DIR/mempal-fast.py"
 
 # Auto-discover the latest installed mempalace plugin in the cache.
 PLUGIN_CACHE_DIR="$(ls -1d "$HOME"/.claude/plugins/cache/mempalace/mempalace/*/ 2>/dev/null | sort -V | tail -1 | sed 's:/$::')"
-WORKSPACE_DIR="$HOME/Projects/memorypalace/.claude-plugin"
 
 # ------------------------------------------------------------------ helpers
 
@@ -107,8 +111,7 @@ do_install() {
     install_cache_plugin_json
     install_cache_hooks_json
     install_wrappers "$PLUGIN_CACHE_DIR/hooks"
-    install_wrappers "$WORKSPACE_DIR/hooks"
-    echo "→ installed customizations into cache + workspace"
+    echo "→ installed customizations into plugin cache"
 }
 
 # ------------------------------------------------------------------ verify
@@ -127,10 +130,6 @@ verify() {
     check_grep "$PLUGIN_CACHE_DIR/plugin.json" "palace-mcp-dispatch.sh"
     check_grep "$PLUGIN_CACHE_DIR/hooks/mempal-stop-hook.sh" "mempal-fast.py"
     check_grep "$PLUGIN_CACHE_DIR/hooks/mempal-precompact-hook.sh" "mempal-fast.py"
-
-    echo "workspace:"
-    check_grep "$WORKSPACE_DIR/hooks/mempal-stop-hook.sh" "mempal-fast.py"
-    check_grep "$WORKSPACE_DIR/hooks/mempal-precompact-hook.sh" "mempal-fast.py"
 
     [ $fail -eq 0 ] && echo "ALL OK" || { echo "FAILED — run: palace-mode install" >&2; exit 1; }
 }

--- a/clients/palace-mode
+++ b/clients/palace-mode
@@ -1,0 +1,147 @@
+#!/bin/bash
+# palace-mode — manage local/remote palace switching and customizations.
+#
+# Subcommands:
+#   palace-mode                 # show current mode + customization status
+#   palace-mode local           # switch hooks/MCP to in-process palace
+#   palace-mode remote [URL]    # switch hooks/MCP to daemon (default URL)
+#   palace-mode install         # re-apply all customizations (run after plugin updates)
+#   palace-mode verify          # check that all customizations are in place
+
+set -euo pipefail
+
+SETTINGS="$HOME/.claude/settings.local.json"
+DEFAULT_URL="http://disks.jphe.in:8085"
+DEFAULT_KEY="adb43b99effac3aced2c82de54827850c6da1fbf4a5e473e1938529b27c08ab3"
+
+# Resolve clients dir relative to this script (works as symlink too).
+CLIENTS_DIR="$(cd -- "$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")" &> /dev/null && pwd)"
+DISPATCH="$CLIENTS_DIR/palace-mcp-dispatch.sh"
+FAST="$CLIENTS_DIR/mempal-fast.py"
+
+# Auto-discover the latest installed mempalace plugin in the cache.
+PLUGIN_CACHE_DIR="$(ls -1d "$HOME"/.claude/plugins/cache/mempalace/mempalace/*/ 2>/dev/null | sort -V | tail -1 | sed 's:/$::')"
+WORKSPACE_DIR="$HOME/Projects/memorypalace/.claude-plugin"
+
+# ------------------------------------------------------------------ helpers
+
+show_status() {
+    python3 - <<PY
+import json
+d = json.load(open("$SETTINGS"))
+url = d.get("env", {}).get("PALACE_DAEMON_URL", "")
+print("Mode: " + ("remote (" + url + ")" if url else "local (no daemon)"))
+PY
+}
+
+set_mode_remote() {
+    url="${1:-$DEFAULT_URL}"
+    python3 - <<PY
+import json
+p = "$SETTINGS"
+d = json.load(open(p))
+env = d.setdefault("env", {})
+env["PALACE_DAEMON_URL"] = "$url"
+env["PALACE_API_KEY"] = "$DEFAULT_KEY"
+json.dump(d, open(p, "w"), indent=4)
+PY
+    echo "→ remote mode (PALACE_DAEMON_URL=$url)"
+}
+
+set_mode_local() {
+    python3 - <<PY
+import json
+p = "$SETTINGS"
+d = json.load(open(p))
+env = d.setdefault("env", {})
+env.pop("PALACE_DAEMON_URL", None)
+env.pop("PALACE_API_KEY", None)
+json.dump(d, open(p, "w"), indent=4)
+PY
+    echo "→ local mode"
+}
+
+# ------------------------------------------------------------------ install
+
+install_wrappers() {
+    local hooks_dir="$1"
+    [ -d "$hooks_dir" ] || return 0
+    cat > "$hooks_dir/mempal-stop-hook.sh" <<EOF
+#!/bin/bash
+exec python3 $FAST stop
+EOF
+    cat > "$hooks_dir/mempal-precompact-hook.sh" <<EOF
+#!/bin/bash
+exec python3 $FAST precompact
+EOF
+    chmod +x "$hooks_dir"/mempal-{stop,precompact}-hook.sh
+}
+
+install_cache_plugin_json() {
+    [ -f "$PLUGIN_CACHE_DIR/plugin.json" ] || return 0
+    python3 - <<PY
+import json, sys
+p = "$PLUGIN_CACHE_DIR/plugin.json"
+d = json.load(open(p))
+d["mcpServers"] = {"mempalace": {"command": "$DISPATCH"}}
+json.dump(d, open(p, "w"), indent=2)
+PY
+}
+
+install_cache_hooks_json() {
+    [ -d "$PLUGIN_CACHE_DIR/hooks" ] || return 0
+    cat > "$PLUGIN_CACHE_DIR/hooks/hooks.json" <<EOF
+{
+  "description": "MemPalace auto-save and pre-compact hooks",
+  "hooks": {
+    "Stop": [{"hooks": [{"type": "command", "command": "bash \${CLAUDE_PLUGIN_ROOT}/hooks/mempal-stop-hook.sh"}]}],
+    "PreCompact": [{"hooks": [{"type": "command", "command": "bash \${CLAUDE_PLUGIN_ROOT}/hooks/mempal-precompact-hook.sh"}]}]
+  }
+}
+EOF
+}
+
+do_install() {
+    [ -x "$DISPATCH" ] || { echo "missing dispatcher: $DISPATCH" >&2; exit 1; }
+    [ -x "$FAST"     ] || { echo "missing fast-path:  $FAST"     >&2; exit 1; }
+    install_cache_plugin_json
+    install_cache_hooks_json
+    install_wrappers "$PLUGIN_CACHE_DIR/hooks"
+    install_wrappers "$WORKSPACE_DIR/hooks"
+    echo "→ installed customizations into cache + workspace"
+}
+
+# ------------------------------------------------------------------ verify
+
+verify() {
+    local fail=0
+    check() { if [ -e "$1" ]; then echo "  ok    $1"; else echo "  MISS  $1"; fail=1; fi; }
+    check_x() { if [ -x "$1" ]; then echo "  ok    $1"; else echo "  N/X   $1"; fail=1; fi; }
+    check_grep() { if grep -q -- "$2" "$1" 2>/dev/null; then echo "  ok    $1 contains $2"; else echo "  BAD   $1 missing $2"; fail=1; fi; }
+
+    echo "shared scripts:"
+    check_x "$DISPATCH"
+    check_x "$FAST"
+
+    echo "cache plugin:"
+    check_grep "$PLUGIN_CACHE_DIR/plugin.json" "palace-mcp-dispatch.sh"
+    check_grep "$PLUGIN_CACHE_DIR/hooks/mempal-stop-hook.sh" "mempal-fast.py"
+    check_grep "$PLUGIN_CACHE_DIR/hooks/mempal-precompact-hook.sh" "mempal-fast.py"
+
+    echo "workspace:"
+    check_grep "$WORKSPACE_DIR/hooks/mempal-stop-hook.sh" "mempal-fast.py"
+    check_grep "$WORKSPACE_DIR/hooks/mempal-precompact-hook.sh" "mempal-fast.py"
+
+    [ $fail -eq 0 ] && echo "ALL OK" || { echo "FAILED — run: palace-mode install" >&2; exit 1; }
+}
+
+# ------------------------------------------------------------------ dispatch
+
+case "${1:-status}" in
+    status|"")  show_status ;;
+    local)      set_mode_local ;;
+    remote)     set_mode_remote "${2:-}" ;;
+    install)    do_install; verify ;;
+    verify)     verify ;;
+    *)          echo "usage: palace-mode [status|local|remote [URL]|install|verify]" >&2; exit 1 ;;
+esac

--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ import messages
 
 # ── Config (env vars override CLI defaults) ───────────────────────────────────
 
-VERSION = "1.5.1"
+VERSION = "1.6.0"
 DEFAULT_HOST = os.getenv("PALACE_HOST", "0.0.0.0")
 DEFAULT_PORT = int(os.getenv("PALACE_PORT", "8085"))
 DEFAULT_PALACE = os.getenv("PALACE_PATH", "")
@@ -459,6 +459,125 @@ async def stats(x_api_key: str | None = Header(default=None)):
     ])
     kg, graph, status = [_unwrap(r) for r in responses]
     return {"kg": kg, "graph": graph, "status": status}
+
+
+def _kg_path() -> str:
+    """KG sqlite path. Lives next to chroma.sqlite3 inside the palace dir."""
+    return os.path.join(_mp._config.palace_path, "knowledge_graph.sqlite3")
+
+
+def _read_kg_direct() -> tuple[list[dict], list[dict]]:
+    """Read-only snapshot of KG entities + triples.
+
+    The KG is a separate SQLite file from the ChromaDB store the daemon
+    coordinates writes for, so a read here does not cross the
+    single-writer invariant. Opens read-only via URI mode so it cannot
+    create the file or mutate state. Schema differences (older palaces,
+    in-progress migrations) are tolerated by catching OperationalError
+    on each query.
+    """
+    kg_path = _kg_path()
+    if not os.path.isfile(kg_path):
+        return [], []
+    try:
+        conn = sqlite3.connect(f"file:{kg_path}?mode=ro", uri=True, timeout=5)
+        conn.row_factory = sqlite3.Row
+    except sqlite3.OperationalError:
+        return [], []
+
+    entities: list[dict] = []
+    triples: list[dict] = []
+    try:
+        try:
+            for r in conn.execute("SELECT id, name, type, properties FROM entities"):
+                try:
+                    props = json.loads(r["properties"] or "{}")
+                except (TypeError, ValueError):
+                    props = {}
+                entities.append({
+                    "id": r["id"],
+                    "name": r["name"],
+                    "type": r["type"] or "unknown",
+                    "properties": props,
+                })
+        except sqlite3.OperationalError:
+            pass
+        try:
+            for r in conn.execute(
+                "SELECT subject, predicate, object, valid_from, valid_to, "
+                "confidence, source_file FROM triples"
+            ):
+                triples.append({
+                    "subject": r["subject"],
+                    "predicate": r["predicate"],
+                    "object": r["object"],
+                    "valid_from": r["valid_from"],
+                    "valid_to": r["valid_to"],
+                    "confidence": r["confidence"],
+                    "source_file": r["source_file"],
+                })
+        except sqlite3.OperationalError:
+            pass
+    finally:
+        conn.close()
+    return entities, triples
+
+
+@app.get("/graph")
+async def graph(x_api_key: str | None = Header(default=None)):
+    """Single-shot structural snapshot for SME-style consumers.
+
+    Mirrors `/stats`'s asyncio.gather pattern but adds:
+    - rooms-per-wing fan-out (parallel)
+    - direct sqlite read of the KG (no extra MCP roundtrip)
+
+    Replaces what an SME adapter would otherwise compose by serially
+    calling list_wings + list_rooms × N + list_tunnels + kg_stats over
+    HTTP. On the 151K-drawer canonical palace, list_wings alone takes
+    ~30s; the gather here finishes in well under that.
+    """
+    _check_auth(x_api_key)
+
+    def _mcp(tool: str, args: dict, rid: int) -> dict:
+        return {
+            "jsonrpc": "2.0", "id": rid,
+            "method": "tools/call",
+            "params": {"name": tool, "arguments": args},
+        }
+
+    # Phase 1: parallel-gather the once-per-palace tools.
+    wings_resp, tunnels_resp, kg_stats_resp = await asyncio.gather(
+        _call(_mcp("mempalace_list_wings", {}, 1)),
+        _call(_mcp("mempalace_list_tunnels", {}, 2)),
+        _call(_mcp("mempalace_kg_stats", {}, 3)),
+    )
+    wings_payload = _unwrap(wings_resp) or {}
+    wings = wings_payload.get("wings") or {}
+
+    # Phase 2: parallel list_rooms per wing.
+    if wings:
+        room_responses = await asyncio.gather(*[
+            _call(_mcp("mempalace_list_rooms", {"wing": w}, 100 + i))
+            for i, w in enumerate(wings)
+        ])
+        rooms = [
+            {"wing": w, "rooms": (_unwrap(r) or {}).get("rooms", {})}
+            for w, r in zip(wings, room_responses)
+        ]
+    else:
+        rooms = []
+
+    # Phase 3: KG entities + triples via direct read-only sqlite.
+    kg_entities, kg_triples = await asyncio.to_thread(_read_kg_direct)
+
+    return {
+        "wings": wings,
+        "rooms": rooms,
+        "tunnels": _unwrap(tunnels_resp) or [],
+        "kg_entities": kg_entities,
+        "kg_triples": kg_triples,
+        "kg_stats": _unwrap(kg_stats_resp) or {},
+    }
 
 
 @app.post("/flush")

--- a/main.py
+++ b/main.py
@@ -158,19 +158,26 @@ def _pending_writes_path() -> str:
     return os.path.join(parent, "palace-daemon-pending.jsonl")
 
 
-def _enqueue_pending_write(payload: dict) -> None:
-    """Append a silent-save payload to the pending-writes queue."""
+async def _enqueue_pending_write(payload: dict) -> None:
+    """Append a silent-save payload to the pending-writes queue (off-loop)."""
     path = _pending_writes_path()
     line = json.dumps({"payload": payload, "enqueued_at": datetime.now().isoformat()})
-    with open(path, "a", encoding="utf-8") as f:
-        f.write(line + "\n")
+
+    def _append():
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+
+    await asyncio.to_thread(_append)
 
 
 async def _drain_pending_writes() -> int:
     """Replay queued silent-saves after a rebuild completes.
 
     Rename-then-read so a concurrent /silent-save appending after the rename
-    lands in a fresh pending file, not the one we're draining.
+    lands in a fresh pending file, not the one we're draining. Each entry is
+    replayed under _write_sem to honour _do_silent_save_write's contract.
+    Failed entries are quarantined to a timestamped file so the next drain
+    pass doesn't replay successful saves.
     """
     path = _pending_writes_path()
     if not os.path.isfile(path):
@@ -181,19 +188,28 @@ async def _drain_pending_writes() -> int:
     except OSError:
         return 0
     count = 0
+    failed_lines: list[str] = []
     try:
         with open(proc_path, encoding="utf-8") as f:
             lines = [ln for ln in f.readlines() if ln.strip()]
         for line in lines:
             try:
                 entry = json.loads(line)
-                result = await _do_silent_save_write(entry["payload"])
+                async with _write_sem:
+                    result = await _do_silent_save_write(entry["payload"])
                 if result.get("success"):
                     count += 1
                 else:
                     _log.warning("drain: replay failed: %s", result.get("error"))
+                    failed_lines.append(line)
             except Exception:
                 _log.exception("drain: entry replay raised")
+                failed_lines.append(line)
+        if failed_lines:
+            qpath = proc_path + ".failed-" + datetime.now().strftime("%Y%m%d%H%M%S")
+            with open(qpath, "w", encoding="utf-8") as f:
+                f.writelines(failed_lines)
+            _log.warning("drain: %d entries quarantined at %s", len(failed_lines), qpath)
         os.remove(proc_path)
     except Exception:
         _log.exception("drain: read failed; leaving %s in place", proc_path)
@@ -273,7 +289,7 @@ async def lifespan(app: FastAPI):
     # occasionally segfaults on the very first request if opened cold; opening
     # it here (before yield) ensures the PersistentClient is fully initialized.
     try:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, _mp.handle_request, {
             "jsonrpc": "2.0", "id": "warmup", "method": "ping", "params": {}
         })
@@ -537,11 +553,31 @@ async def silent_save(request: Request, x_api_key: str | None = Header(default=N
         raise HTTPException(status_code=400, detail="'entry' is required")
 
     themes = body.get("themes") or []
-    msg_count = int(body.get("message_count") or 1)
+    raw_msg_count = body.get("message_count")
+    if raw_msg_count is None:
+        msg_count = 1
+    else:
+        try:
+            msg_count = int(raw_msg_count)
+        except (TypeError, ValueError):
+            raise HTTPException(
+                status_code=400,
+                detail="'message_count' must be an integer",
+            )
+        if msg_count <= 0:
+            msg_count = 1
 
-    # Fast-path: repair already in progress, queue immediately.
-    if _repair_state["in_progress"]:
-        _enqueue_pending_write(body)
+    # Queue only when /repair is doing a rebuild — other modes (light/scan/
+    # prune) don't replace the collection out from under in-flight writes,
+    # so silent-saves can proceed normally.
+    queue_writes = (
+        _repair_state["in_progress"]
+        and _repair_state.get("mode") == "rebuild"
+    )
+
+    # Fast-path: rebuild in progress, queue immediately.
+    if queue_writes:
+        await _enqueue_pending_write(body)
         return {
             "count": msg_count,
             "themes": themes,
@@ -551,8 +587,11 @@ async def silent_save(request: Request, x_api_key: str | None = Header(default=N
 
     # Normal path: acquire write slot, re-check flag under lock, then write.
     async with _write_sem:
-        if _repair_state["in_progress"]:
-            _enqueue_pending_write(body)
+        if (
+            _repair_state["in_progress"]
+            and _repair_state.get("mode") == "rebuild"
+        ):
+            await _enqueue_pending_write(body)
             return {
                 "count": msg_count,
                 "themes": themes,

--- a/main.py
+++ b/main.py
@@ -466,6 +466,64 @@ def _kg_path() -> str:
     return os.path.join(_mp._config.palace_path, "knowledge_graph.sqlite3")
 
 
+def _chroma_path() -> str:
+    """Chroma sqlite path inside the palace dir."""
+    return os.path.join(_mp._config.palace_path, "chroma.sqlite3")
+
+
+def _read_wings_rooms_direct() -> tuple[dict[str, int], list[dict]]:
+    """Read wings + rooms directly from chroma.sqlite3 (read-only, off-loop).
+
+    Bypasses the MCP fan-out (list_wings + list_rooms × N) which serializes
+    through the read semaphore and stalls under load. Direct sqlite GROUP BY
+    on the embedding_metadata table is ~200× faster on the canonical 151K-
+    drawer palace (~0.4s vs 60-120s under contention) and consumes zero
+    semaphore slots.
+
+    Schema is the ChromaDB persistent client's internal layout — not part
+    of mempalace's public API. Tolerated by catching OperationalError; if
+    the schema ever drifts, /graph degrades to empty wings/rooms (the SME
+    adapter then falls back to its MCP composition path).
+    """
+    chroma = _chroma_path()
+    if not os.path.isfile(chroma):
+        return {}, []
+    try:
+        conn = sqlite3.connect(f"file:{chroma}?mode=ro", uri=True, timeout=5)
+    except sqlite3.OperationalError:
+        return {}, []
+
+    wings: dict[str, int] = {}
+    rooms_by_wing: dict[str, dict[str, int]] = {}
+    try:
+        try:
+            for name, n in conn.execute(
+                "SELECT string_value, COUNT(*) FROM embedding_metadata "
+                "WHERE key='wing' GROUP BY string_value"
+            ):
+                if name:
+                    wings[name] = n
+        except sqlite3.OperationalError:
+            pass
+        try:
+            for wing, room, n in conn.execute(
+                "SELECT em_w.string_value, em_r.string_value, COUNT(*) "
+                "FROM embedding_metadata em_w "
+                "JOIN embedding_metadata em_r ON em_w.id = em_r.id "
+                "WHERE em_w.key='wing' AND em_r.key='room' "
+                "GROUP BY em_w.string_value, em_r.string_value"
+            ):
+                if wing and room:
+                    rooms_by_wing.setdefault(wing, {})[room] = n
+        except sqlite3.OperationalError:
+            pass
+    finally:
+        conn.close()
+
+    rooms = [{"wing": w, "rooms": rooms_by_wing.get(w, {})} for w in wings]
+    return wings, rooms
+
+
 def _read_kg_direct() -> tuple[list[dict], list[dict]]:
     """Read-only snapshot of KG entities + triples.
 
@@ -545,41 +603,40 @@ async def graph(x_api_key: str | None = Header(default=None)):
             "params": {"name": tool, "arguments": args},
         }
 
-    # Phase 1: parallel-gather the once-per-palace tools.
-    # Note: tunnels come from `mempalace_graph_stats.top_tunnels` rather
-    # than `mempalace_list_tunnels`. As of mempalace 3.3.4 the two
-    # disagree on what counts as a tunnel — graph_stats reports 9 on the
-    # canonical palace, list_tunnels returns []. Until that's reconciled
-    # upstream, prefer graph_stats which `/stats` already exposes, so
-    # `/graph.tunnels` and `/stats.graph.tunnel_rooms` always agree.
-    wings_resp, graph_stats_resp, kg_stats_resp = await asyncio.gather(
-        _call(_mcp("mempalace_list_wings", {}, 1)),
-        _call(_mcp("mempalace_graph_stats", {}, 2)),
-        _call(_mcp("mempalace_kg_stats", {}, 3)),
+    # Phase 1: parallel reads.
+    #
+    # MCP path (cheap tools — graph_stats is computed in mempalace, not
+    # walked, and kg_stats is a single sqlite count): graph_stats gives us
+    # tunnels via top_tunnels (mempalace 3.3.4's mempalace_list_tunnels
+    # returns [] on palaces where graph_stats reports tunnels — bug
+    # tracked in docs/graph-endpoint.md Part 2). kg_stats gives the
+    # entities/triples summary the SME adapter already consumes.
+    #
+    # Direct sqlite path (no semaphore, ~0.4s on a 151K-drawer palace):
+    # wings, rooms-per-wing, KG entities + triples. These are the
+    # expensive parts when fanned out via MCP (list_wings is ~30s,
+    # list_rooms × N wings serializes through the 4-slot read semaphore
+    # and starves under load). Reading the underlying sqlite directly
+    # bypasses the fan-out entirely.
+    graph_stats_task = _call(_mcp("mempalace_graph_stats", {}, 1))
+    kg_stats_task    = _call(_mcp("mempalace_kg_stats",    {}, 2))
+    wings_rooms_task = asyncio.to_thread(_read_wings_rooms_direct)
+    kg_direct_task   = asyncio.to_thread(_read_kg_direct)
+
+    graph_stats_resp, kg_stats_resp, (wings, rooms), (kg_entities, kg_triples) = (
+        await asyncio.gather(
+            graph_stats_task,
+            kg_stats_task,
+            wings_rooms_task,
+            kg_direct_task,
+        )
     )
-    wings_payload = _unwrap(wings_resp) or {}
-    wings = wings_payload.get("wings") or {}
+
     graph_payload = _unwrap(graph_stats_resp) or {}
     tunnels = [
         {"room": t.get("room"), "wings": t.get("wings", [])}
         for t in (graph_payload.get("top_tunnels") or [])
     ]
-
-    # Phase 2: parallel list_rooms per wing.
-    if wings:
-        room_responses = await asyncio.gather(*[
-            _call(_mcp("mempalace_list_rooms", {"wing": w}, 100 + i))
-            for i, w in enumerate(wings)
-        ])
-        rooms = [
-            {"wing": w, "rooms": (_unwrap(r) or {}).get("rooms", {})}
-            for w, r in zip(wings, room_responses)
-        ]
-    else:
-        rooms = []
-
-    # Phase 3: KG entities + triples via direct read-only sqlite.
-    kg_entities, kg_triples = await asyncio.to_thread(_read_kg_direct)
 
     return {
         "wings": wings,

--- a/main.py
+++ b/main.py
@@ -39,12 +39,26 @@ import messages
 
 # ── Config (env vars override CLI defaults) ───────────────────────────────────
 
-VERSION = "1.5.0"
+VERSION = "1.5.1"
 DEFAULT_HOST = os.getenv("PALACE_HOST", "0.0.0.0")
 DEFAULT_PORT = int(os.getenv("PALACE_PORT", "8085"))
 DEFAULT_PALACE = os.getenv("PALACE_PATH", "")
 API_KEY = os.getenv("PALACE_API_KEY", "")  # read at startup for argparse default; auth checks re-read from env dynamically
 PALACE_MAX_CONCURRENCY = int(os.getenv("PALACE_MAX_CONCURRENCY", "4"))
+
+# Canonical topic for Stop-hook auto-save checkpoint diary entries.
+# Defined here so /silent-save can canonicalize at the daemon boundary
+# even when client code drifts. Must match clients/hook.py and
+# clients/mempal-fast.py and the read-side filter list in
+# mempalace.searcher._CHECKPOINT_TOPICS.
+CHECKPOINT_TOPIC = "checkpoint"
+# Legacy synonyms that older clients (or future buggy ones) might write.
+# When /silent-save sees one of these, it rewrites to CHECKPOINT_TOPIC
+# and emits a warning log line. The read-side filter accepts both.
+CHECKPOINT_TOPIC_SYNONYMS = ("auto-save",)
+# Valid kind= values for /search and /context. Mirrors the enum on the
+# mempalace_search MCP tool's input_schema. Anything else => 400.
+_VALID_KINDS = ("content", "checkpoint", "all")
 
 # Read ops: up to N concurrent.
 # Regular write ops: up to N//2 concurrent (mempalace ≥3.3.2 is internally safe).
@@ -216,6 +230,28 @@ async def _drain_pending_writes() -> int:
     return count
 
 
+def _canonical_topic(topic: str) -> str:
+    """Canonicalize a Stop-hook checkpoint topic at the daemon boundary.
+
+    All canonical and synonym values become ``CHECKPOINT_TOPIC``. Any
+    other value is left as-is — the caller may have legitimately used
+    a non-checkpoint topic name on this diary write (e.g. "musings",
+    "decisions") and we shouldn't clobber that.
+
+    Defense in depth: clients (clients/hook.py, clients/mempal-fast.py,
+    mempalace.hooks_cli) already write the canonical value; this
+    rewrite catches future drift or buggy callers without rejecting the
+    save outright.
+    """
+    if topic in CHECKPOINT_TOPIC_SYNONYMS:
+        _log.warning(
+            "silent-save: rewriting non-canonical checkpoint topic %r → %r",
+            topic, CHECKPOINT_TOPIC,
+        )
+        return CHECKPOINT_TOPIC
+    return topic
+
+
 async def _do_silent_save_write(payload: dict) -> dict:
     """Write a diary checkpoint via tool_diary_write in an executor.
 
@@ -224,7 +260,7 @@ async def _do_silent_save_write(payload: dict) -> dict:
     """
     wing = payload.get("wing", "") or ""
     entry = payload.get("entry", "")
-    topic = payload.get("topic", "checkpoint")
+    topic = _canonical_topic(payload.get("topic", CHECKPOINT_TOPIC))
     agent_name = payload.get("agent_name", "session-hook")
     loop = asyncio.get_running_loop()
 
@@ -339,25 +375,58 @@ async def health():
     return {"status": "ok", "daemon": "palace-daemon", "version": VERSION, "palace": result}
 
 
+def _search_args(query: str, limit: int, kind: str) -> dict:
+    """Build the mempalace_search MCP tool arguments dict.
+
+    Param-name fidelity matters: the MCP tool's input_schema declares
+    ``limit`` and ``kind``, and unknown keys are silently dropped by the
+    schema-whitelist filter in ``mempalace.mcp_server.handle_request``.
+    Earlier daemon versions passed ``max_results`` here, which never
+    bound and quietly capped every /search response at the default 5.
+    """
+    if kind not in _VALID_KINDS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"kind must be one of {_VALID_KINDS}; got {kind!r}",
+        )
+    return {"query": query, "limit": limit, "kind": kind}
+
+
 @app.get("/search")
-async def search(q: str, limit: int = 5, x_api_key: str | None = Header(default=None)):
+async def search(
+    q: str,
+    limit: int = 5,
+    kind: str = "content",
+    x_api_key: str | None = Header(default=None),
+):
+    """Semantic search. ``kind`` defaults to ``"content"`` which excludes
+    Stop-hook auto-save checkpoints (session-summary noise that drowns
+    out real content under vector similarity). Pass ``kind="all"`` to
+    preserve pre-2026-04-25 behavior, or ``kind="checkpoint"`` for
+    recovery/audit lookups."""
     _check_auth(x_api_key)
     result = await _call({
         "jsonrpc": "2.0", "id": 1,
         "method": "tools/call",
-        "params": {"name": "mempalace_search", "arguments": {"query": q, "max_results": limit}},
+        "params": {"name": "mempalace_search", "arguments": _search_args(q, limit, kind)},
     })
     return _unwrap(result)
 
 
 @app.get("/context")
-async def context(topic: str, limit: int = 5, x_api_key: str | None = Header(default=None)):
-    # Alias for /search with a semantically friendlier name for LLM tool prompts
+async def context(
+    topic: str,
+    limit: int = 5,
+    kind: str = "content",
+    x_api_key: str | None = Header(default=None),
+):
+    """Alias for /search with a semantically friendlier name for LLM tool
+    prompts. Same ``kind`` semantics as /search."""
     _check_auth(x_api_key)
     result = await _call({
         "jsonrpc": "2.0", "id": 1,
         "method": "tools/call",
-        "params": {"name": "mempalace_search", "arguments": {"query": topic, "max_results": limit}},
+        "params": {"name": "mempalace_search", "arguments": _search_args(topic, limit, kind)},
     })
     return _unwrap(result)
 

--- a/main.py
+++ b/main.py
@@ -257,14 +257,10 @@ async def lifespan(app: FastAPI):
     import logging
     logger = logging.getLogger(__name__)
     
-    # Register signal handlers for graceful shutdown
-    def handle_exit(sig, frame):
-        logger.warning("Received signal %s, shutting down...", sig)
-        # _mp handles its own state, but we ensure the daemon stops accepting new tasks
-        sys.exit(0)
-    
-    signal.signal(signal.SIGINT, handle_exit)
-    signal.signal(signal.SIGTERM, handle_exit)
+    # Uvicorn installs its own SIGINT/SIGTERM handlers that shut down gracefully;
+    # we don't need to override them. Calling sys.exit() from inside an asyncio
+    # signal handler tears the event loop down mid-coroutine and skips lifespan
+    # shutdown (the flush). Leave signal handling to uvicorn.
 
     moved = quarantine_stale_hnsw(_mp._config.palace_path)
     if moved:
@@ -272,7 +268,19 @@ async def lifespan(app: FastAPI):
             "Quarantined %d stale HNSW segment(s) — ChromaDB will rebuild indexes: %s",
             len(moved), moved,
         )
-    
+
+    # Warm the ChromaDB client before accepting traffic. The Rust HNSW binding
+    # occasionally segfaults on the very first request if opened cold; opening
+    # it here (before yield) ensures the PersistentClient is fully initialized.
+    try:
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, _mp.handle_request, {
+            "jsonrpc": "2.0", "id": "warmup", "method": "ping", "params": {}
+        })
+        logger.info("Palace client warmed up.")
+    except Exception as e:
+        logger.warning("Warmup ping failed (non-fatal): %s", e)
+
     yield
     
     # --- Shutdown: Silent Save / Flush ---

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ Roadmap:
 import argparse
 import asyncio
 import json
+import logging
 import os
 import sqlite3
 import sys
@@ -31,11 +32,14 @@ from fastapi import FastAPI, Header, HTTPException, Request
 from fastapi.responses import JSONResponse
 
 import mempalace.mcp_server as _mp
+from mempalace import repair as _mp_repair
 from mempalace.backends.chroma import quarantine_stale_hnsw
+
+import messages
 
 # ── Config (env vars override CLI defaults) ───────────────────────────────────
 
-VERSION = "1.4.2"
+VERSION = "1.5.0"
 DEFAULT_HOST = os.getenv("PALACE_HOST", "0.0.0.0")
 DEFAULT_PORT = int(os.getenv("PALACE_PORT", "8085"))
 DEFAULT_PALACE = os.getenv("PALACE_PATH", "")
@@ -49,6 +53,14 @@ PALACE_MAX_CONCURRENCY = int(os.getenv("PALACE_MAX_CONCURRENCY", "4"))
 _read_sem = asyncio.Semaphore(PALACE_MAX_CONCURRENCY)
 _write_sem = asyncio.Semaphore(max(1, PALACE_MAX_CONCURRENCY // 2))
 _mine_sem = asyncio.Semaphore(1)
+
+# Repair state — when in_progress is True, /silent-save queues instead of writing.
+# The fast-path check is lock-free (single-assignment dict); _repair_lock serializes
+# start/end transitions and prevents overlapping repairs.
+_repair_state: dict[str, Any] = {"in_progress": False, "mode": None, "started_at": None}
+_repair_lock = asyncio.Lock()
+
+_log = logging.getLogger("palace-daemon")
 
 # Tools that only read state — everything else is treated as a write.
 _READ_TOOLS = {
@@ -90,21 +102,129 @@ def _sem_for(request_dict: dict) -> asyncio.Semaphore:
 
 async def _auto_repair():
     """Trigger index recovery and reload the mempalace client."""
-    import logging
-    logger = logging.getLogger(__name__)
-    
     loop = asyncio.get_running_loop()
     palace_path = _mp._config.palace_path
     moved = await loop.run_in_executor(None, quarantine_stale_hnsw, palace_path)
     if moved:
-        logger.warning("AUTO-REPAIR: Quarantined %d stale HNSW segments. Reloading client.", len(moved))
-        # Clear client cache to force a fresh PersistentClient (which triggers rebuild)
+        _log.warning("AUTO-REPAIR: Quarantined %d stale HNSW segments. Reloading client.", len(moved))
         _mp._client_cache = None
         _mp._collection_cache = None
         return len(moved)
-    
-    logger.info("AUTO-REPAIR: No stale segments found during scan.")
+    _log.info("AUTO-REPAIR: No stale segments found during scan.")
     return 0
+
+
+# ── Exclusive palace context (for rebuild) ───────────────────────────────────
+
+@asynccontextmanager
+async def _exclusive_palace():
+    """Acquire every semaphore slot — no daemon-mediated work runs until release.
+
+    Used by /repair mode=rebuild, which deletes and recreates the collection
+    (backend-level, outside the ChromaCollection flock). Any in-flight write
+    would race with the delete/create and be lost. Holding every slot makes
+    sure nothing daemon-mediated is mid-flight when the rebuild starts.
+    """
+    read_slots = PALACE_MAX_CONCURRENCY
+    write_slots = max(1, PALACE_MAX_CONCURRENCY // 2)
+    r_held = 0
+    w_held = 0
+    m_held = False
+    try:
+        for _ in range(read_slots):
+            await _read_sem.acquire()
+            r_held += 1
+        for _ in range(write_slots):
+            await _write_sem.acquire()
+            w_held += 1
+        await _mine_sem.acquire()
+        m_held = True
+        yield
+    finally:
+        if m_held:
+            _mine_sem.release()
+        for _ in range(w_held):
+            _write_sem.release()
+        for _ in range(r_held):
+            _read_sem.release()
+
+
+# ── Pending-writes queue (held during rebuild) ───────────────────────────────
+
+def _pending_writes_path() -> str:
+    """Location of the jsonl queue that holds silent-saves during rebuild."""
+    palace_path = _mp._config.palace_path
+    parent = os.path.dirname(palace_path.rstrip("/")) or "/tmp"
+    return os.path.join(parent, "palace-daemon-pending.jsonl")
+
+
+def _enqueue_pending_write(payload: dict) -> None:
+    """Append a silent-save payload to the pending-writes queue."""
+    path = _pending_writes_path()
+    line = json.dumps({"payload": payload, "enqueued_at": datetime.now().isoformat()})
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(line + "\n")
+
+
+async def _drain_pending_writes() -> int:
+    """Replay queued silent-saves after a rebuild completes.
+
+    Rename-then-read so a concurrent /silent-save appending after the rename
+    lands in a fresh pending file, not the one we're draining.
+    """
+    path = _pending_writes_path()
+    if not os.path.isfile(path):
+        return 0
+    proc_path = path + ".processing"
+    try:
+        os.rename(path, proc_path)
+    except OSError:
+        return 0
+    count = 0
+    try:
+        with open(proc_path, encoding="utf-8") as f:
+            lines = [ln for ln in f.readlines() if ln.strip()]
+        for line in lines:
+            try:
+                entry = json.loads(line)
+                result = await _do_silent_save_write(entry["payload"])
+                if result.get("success"):
+                    count += 1
+                else:
+                    _log.warning("drain: replay failed: %s", result.get("error"))
+            except Exception:
+                _log.exception("drain: entry replay raised")
+        os.remove(proc_path)
+    except Exception:
+        _log.exception("drain: read failed; leaving %s in place", proc_path)
+    return count
+
+
+async def _do_silent_save_write(payload: dict) -> dict:
+    """Write a diary checkpoint via tool_diary_write in an executor.
+
+    Caller is expected to hold _write_sem. Returns mempalace's raw dict
+    (typically {"success": True, "entry_id": ...} or {"success": False, "error": ...}).
+    """
+    wing = payload.get("wing", "") or ""
+    entry = payload.get("entry", "")
+    topic = payload.get("topic", "checkpoint")
+    agent_name = payload.get("agent_name", "session-hook")
+    loop = asyncio.get_running_loop()
+
+    def _work():
+        from mempalace.mcp_server import tool_diary_write
+        return tool_diary_write(
+            agent_name=agent_name,
+            entry=entry,
+            topic=topic,
+            wing=wing,
+        )
+
+    try:
+        return await loop.run_in_executor(None, _work)
+    except Exception as e:
+        return {"success": False, "error": str(e)}
 
 
 async def _call(request_dict: dict, retry_on_hnsw: bool = True) -> dict:
@@ -384,6 +504,208 @@ async def mine(request: Request, x_api_key: str | None = Header(default=None)):
     }
 
 
+# ── Repair + silent-save ─────────────────────────────────────────────────────
+
+@app.post("/silent-save")
+async def silent_save(request: Request, x_api_key: str | None = Header(default=None)):
+    """
+    Silent Stop-hook save path. Writes a diary checkpoint during normal ops;
+    during /repair mode=rebuild, queues the payload to a jsonl file and
+    returns a themed "held in trust" message. The queue drains automatically
+    when the rebuild completes.
+
+    Body: {
+      session_id, wing, entry, topic?, agent_name?,
+      themes?: [...],       # for the returned systemMessage tag
+      message_count?: int,  # count the hook wants displayed (often len(messages))
+    }
+    """
+    _check_auth(x_api_key)
+    try:
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="invalid JSON")
+    if not body.get("entry"):
+        raise HTTPException(status_code=400, detail="'entry' is required")
+
+    themes = body.get("themes") or []
+    msg_count = int(body.get("message_count") or 1)
+
+    # Fast-path: repair already in progress, queue immediately.
+    if _repair_state["in_progress"]:
+        _enqueue_pending_write(body)
+        return {
+            "count": msg_count,
+            "themes": themes,
+            "queued": True,
+            "systemMessage": messages.save_queued(msg_count, themes),
+        }
+
+    # Normal path: acquire write slot, re-check flag under lock, then write.
+    async with _write_sem:
+        if _repair_state["in_progress"]:
+            _enqueue_pending_write(body)
+            return {
+                "count": msg_count,
+                "themes": themes,
+                "queued": True,
+                "systemMessage": messages.save_queued(msg_count, themes),
+            }
+        result = await _do_silent_save_write(body)
+
+    if result.get("success"):
+        return {
+            "count": msg_count,
+            "themes": themes,
+            "queued": False,
+            "entry_id": result.get("entry_id"),
+            "systemMessage": messages.save_ok(msg_count, themes),
+        }
+    raise HTTPException(
+        status_code=500,
+        detail=f"silent save failed: {result.get('error', 'unknown')}",
+    )
+
+
+@app.post("/repair")
+async def repair(request: Request, x_api_key: str | None = Header(default=None)):
+    """
+    Coordinate a repair with daemon-mediated traffic.
+
+    Body: { "mode": "light" | "scan" | "prune" | "rebuild" }
+      light   — clear caches; next client open re-runs quarantine_stale_hnsw(). Cheap.
+      scan    — find corrupt IDs, write corrupt_ids.txt. Read-only.
+      prune   — delete corrupt IDs via the flock-safe col.delete path.
+      rebuild — destructive: delete + recreate the collection. Holds every
+                semaphore slot; silent-save queues during this window and
+                drains automatically on completion.
+
+    Only one repair at a time. Second call while one is in-flight → 409.
+    """
+    _check_auth(x_api_key)
+    try:
+        body = await request.json() if await request.body() else {}
+    except Exception:
+        body = {}
+    mode = (body.get("mode") or "light").lower()
+    if mode not in ("light", "scan", "prune", "rebuild"):
+        raise HTTPException(
+            status_code=400,
+            detail="mode must be one of: light, scan, prune, rebuild",
+        )
+
+    # Start transition — guarded so two /repair callers can't both begin.
+    async with _repair_lock:
+        if _repair_state["in_progress"]:
+            raise HTTPException(
+                status_code=409,
+                detail=f"repair already in progress (mode={_repair_state['mode']})",
+            )
+        _repair_state["in_progress"] = True
+        _repair_state["mode"] = mode
+        _repair_state["started_at"] = datetime.now().isoformat()
+
+    _log.info(messages.repair_begin(mode))
+    start = datetime.now()
+    result: dict[str, Any] = {}
+    drained = 0
+
+    try:
+        if mode == "light":
+            # Clear cached client + collection. Next touch will re-open and
+            # re-run quarantine_stale_hnsw() via make_client().
+            async with _write_sem:
+                _mp._client_cache = None
+                _mp._collection_cache = None
+                result = {"caches_cleared": True}
+
+        elif mode == "scan":
+            # Read-only: cap at read slot.
+            async with _read_sem:
+                loop = asyncio.get_running_loop()
+                palace_path = _mp._config.palace_path
+                await loop.run_in_executor(None, _mp_repair.scan_palace, palace_path)
+                corrupt_file = os.path.join(palace_path, "corrupt_ids.txt")
+                count = 0
+                if os.path.isfile(corrupt_file):
+                    with open(corrupt_file, encoding="utf-8") as f:
+                        count = sum(1 for ln in f if ln.strip())
+                result = {"corrupt_ids_found": count, "corrupt_file": corrupt_file}
+
+        elif mode == "prune":
+            # Takes flock internally (col.delete). Hold a single write slot so
+            # we don't inflate daemon throughput while repair is running.
+            async with _write_sem:
+                loop = asyncio.get_running_loop()
+                palace_path = _mp._config.palace_path
+                await loop.run_in_executor(
+                    None,
+                    lambda: _mp_repair.prune_corrupt(palace_path=palace_path, confirm=True),
+                )
+                result = {"pruned": True}
+            _mp._client_cache = None
+            _mp._collection_cache = None
+
+        elif mode == "rebuild":
+            # Destructive: deletes + recreates the collection. Hold every
+            # semaphore slot so no daemon-mediated write races the swap.
+            async with _exclusive_palace():
+                loop = asyncio.get_running_loop()
+                palace_path = _mp._config.palace_path
+                await loop.run_in_executor(None, _mp_repair.rebuild_index, palace_path)
+                _mp._client_cache = None
+                _mp._collection_cache = None
+                result = {"rebuilt": True}
+
+    except Exception as e:
+        _log.exception("repair (%s) failed", mode)
+        async with _repair_lock:
+            _repair_state["in_progress"] = False
+            _repair_state["mode"] = None
+            _repair_state["started_at"] = None
+        raise HTTPException(status_code=500, detail=f"repair failed: {e}")
+
+    # Clear the flag BEFORE draining so replayed silent-saves go direct,
+    # not back into the queue.
+    async with _repair_lock:
+        _repair_state["in_progress"] = False
+        _repair_state["mode"] = None
+        _repair_state["started_at"] = None
+
+    if mode == "rebuild":
+        drained = await _drain_pending_writes()
+
+    duration = (datetime.now() - start).total_seconds()
+    _log.info(messages.repair_complete(mode, drained, duration))
+    return {
+        "mode": mode,
+        "result": result,
+        "drained": drained,
+        "duration_s": round(duration, 3),
+        "systemMessage": messages.repair_complete(mode, drained, duration),
+    }
+
+
+@app.get("/repair/status")
+async def repair_status():
+    """Current repair state + pending-writes queue depth."""
+    queue_path = _pending_writes_path()
+    pending = 0
+    if os.path.isfile(queue_path):
+        try:
+            with open(queue_path, encoding="utf-8") as f:
+                pending = sum(1 for ln in f if ln.strip())
+        except OSError:
+            pending = -1
+    return {
+        "in_progress": _repair_state["in_progress"],
+        "mode": _repair_state["mode"],
+        "started_at": _repair_state["started_at"],
+        "pending_writes": pending,
+        "pending_writes_path": queue_path,
+    }
+
+
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 def _unwrap(mcp_response: dict) -> Any:
@@ -410,7 +732,7 @@ def main():
     args = parser.parse_args()
 
     # Simple file lock to prevent multiple daemon instances on the same port.
-    # Use ~/.cache/palace-daemon/ (mode 0o700) instead of /tmp to avoid world-writable exposure.
+    # ~/.cache/palace-daemon/ (mode 0o700) avoids world-writable /tmp exposure.
     lock_dir = Path.home() / ".cache" / "palace-daemon"
     lock_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
     lock_file_path = str(lock_dir / f"daemon-{args.port}.lock")

--- a/main.py
+++ b/main.py
@@ -546,13 +546,24 @@ async def graph(x_api_key: str | None = Header(default=None)):
         }
 
     # Phase 1: parallel-gather the once-per-palace tools.
-    wings_resp, tunnels_resp, kg_stats_resp = await asyncio.gather(
+    # Note: tunnels come from `mempalace_graph_stats.top_tunnels` rather
+    # than `mempalace_list_tunnels`. As of mempalace 3.3.4 the two
+    # disagree on what counts as a tunnel — graph_stats reports 9 on the
+    # canonical palace, list_tunnels returns []. Until that's reconciled
+    # upstream, prefer graph_stats which `/stats` already exposes, so
+    # `/graph.tunnels` and `/stats.graph.tunnel_rooms` always agree.
+    wings_resp, graph_stats_resp, kg_stats_resp = await asyncio.gather(
         _call(_mcp("mempalace_list_wings", {}, 1)),
-        _call(_mcp("mempalace_list_tunnels", {}, 2)),
+        _call(_mcp("mempalace_graph_stats", {}, 2)),
         _call(_mcp("mempalace_kg_stats", {}, 3)),
     )
     wings_payload = _unwrap(wings_resp) or {}
     wings = wings_payload.get("wings") or {}
+    graph_payload = _unwrap(graph_stats_resp) or {}
+    tunnels = [
+        {"room": t.get("room"), "wings": t.get("wings", [])}
+        for t in (graph_payload.get("top_tunnels") or [])
+    ]
 
     # Phase 2: parallel list_rooms per wing.
     if wings:
@@ -573,7 +584,7 @@ async def graph(x_api_key: str | None = Header(default=None)):
     return {
         "wings": wings,
         "rooms": rooms,
-        "tunnels": _unwrap(tunnels_resp) or [],
+        "tunnels": tunnels,
         "kg_entities": kg_entities,
         "kg_triples": kg_triples,
         "kg_stats": _unwrap(kg_stats_resp) or {},

--- a/messages.py
+++ b/messages.py
@@ -1,0 +1,77 @@
+"""
+Themed user-facing strings for palace-daemon.
+
+Keep the voice consistent across save paths, repair operations, and drain
+events. One file, one place to retheme everything.
+
+Glyphs:
+  ✦ — a memory operation (save, drain, held-in-trust)
+  ◈ — a palace operation (repair, reload, backup, restore)
+"""
+
+from typing import Iterable
+
+
+def _theme_tag(themes: Iterable[str]) -> str:
+    items = [t for t in (themes or []) if t]
+    if not items:
+        return ""
+    return " — " + ", ".join(items[:4])
+
+
+def save_ok(count: int, themes: Iterable[str] = ()) -> str:
+    """Silent-save success (palace is healthy)."""
+    if count == 1:
+        return f"✦ 1 memory woven into the palace{_theme_tag(themes)}"
+    return f"✦ {count} memories woven into the palace{_theme_tag(themes)}"
+
+
+def save_queued(count: int, themes: Iterable[str] = ()) -> str:
+    """Silent-save deferred because repair is underway."""
+    if count == 1:
+        return (
+            f"✦ 1 memory held in trust{_theme_tag(themes)} "
+            f"— the palace is being mended"
+        )
+    return (
+        f"✦ {count} memories held in trust{_theme_tag(themes)} "
+        f"— the palace is being mended"
+    )
+
+
+def repair_begin(mode: str) -> str:
+    if mode == "rebuild":
+        return (
+            "◈ Mending begun — the halls are quieted while the index is rebuilt"
+        )
+    if mode == "prune":
+        return "◈ Pruning begun — corrupted threads are being cleared"
+    if mode == "scan":
+        return "◈ Scanning begun — the walls are being read"
+    return "◈ Light maintenance — stale segments are being set aside"
+
+
+def repair_complete(mode: str, drained: int = 0, duration_s: float = 0.0) -> str:
+    dur = f" in {duration_s:.1f}s" if duration_s else ""
+    if mode == "rebuild":
+        if drained:
+            verb = "memory flowed" if drained == 1 else "memories flowed"
+            return (
+                f"◈ The palace is whole again{dur} "
+                f"— {drained} held {verb} home"
+            )
+        return f"◈ The palace is whole again{dur}"
+    if mode == "prune":
+        return f"◈ Pruning complete{dur}"
+    if mode == "scan":
+        return f"◈ Scan complete{dur}"
+    return f"◈ Maintenance complete{dur}"
+
+
+def drain_fail(count: int) -> str:
+    if count == 1:
+        return "✦ 1 held memory could not be placed — kept in the antechamber"
+    return (
+        f"✦ {count} held memories could not be placed "
+        "— kept in the antechamber"
+    )

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# deploy.sh — push palace-daemon main, restart on the daemon host, smoke-test.
+#
+# Assumes:
+#   - You're committed and want to push HEAD to origin/main.
+#   - The deploy host has the repo synced (e.g., via Syncthing).
+#   - palace-daemon is a systemd --user service named "palace-daemon".
+#
+# Usage:
+#   scripts/deploy.sh                       # default host: disks
+#   PALACE_HOST=otherhost scripts/deploy.sh
+
+set -euo pipefail
+
+HOST="${PALACE_HOST:-disks}"
+URL="${PALACE_DAEMON_URL:-http://${HOST}.jphe.in:8085}"
+KEY="${PALACE_API_KEY:-}"
+
+# Fallback: read PALACE_API_KEY from ~/.claude/settings.local.json env block
+# (the source of truth managed by palace-mode).
+if [ -z "$KEY" ] && [ -f "$HOME/.claude/settings.local.json" ]; then
+    KEY=$(python3 -c "
+import json
+d = json.load(open('$HOME/.claude/settings.local.json'))
+print(d.get('env', {}).get('PALACE_API_KEY', ''))
+" 2>/dev/null || echo "")
+fi
+SYNC_GRACE="${PALACE_SYNC_GRACE:-3}"   # seconds to let Syncthing catch up
+HEALTH_TIMEOUT="${PALACE_HEALTH_TIMEOUT:-30}"
+
+step() { printf '\n\033[1m▸ %s\033[0m\n' "$1"; }
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$1"; }
+fail() { printf '  \033[31m✗\033[0m %s\n' "$1" >&2; exit 1; }
+
+step "1/5  push to origin"
+local_sha=$(git rev-parse HEAD)
+git push origin main >/dev/null 2>&1 || fail "git push failed"
+ok "pushed $local_sha → origin/main"
+
+step "2/5  wait for sync to $HOST"
+sleep "$SYNC_GRACE"
+remote_sha=$(ssh "$HOST" "cd /mnt/raid/projects/palace-daemon && git rev-parse HEAD 2>/dev/null || git log -1 --format=%H 2>/dev/null" 2>/dev/null || echo "")
+if [ "$remote_sha" = "$local_sha" ]; then
+    ok "remote at $local_sha"
+elif [ -z "$remote_sha" ]; then
+    ok "remote is not a git checkout — assuming Syncthing-only mirror"
+else
+    echo "  ! remote at $remote_sha (expected $local_sha)"
+    echo "  ! Syncthing may need more time; sleeping ${SYNC_GRACE}s and retrying"
+    sleep "$SYNC_GRACE"
+    remote_sha=$(ssh "$HOST" "cd /mnt/raid/projects/palace-daemon && git rev-parse HEAD" 2>/dev/null || echo "")
+    [ "$remote_sha" = "$local_sha" ] && ok "remote caught up to $local_sha" || fail "sync lag persists; aborting"
+fi
+
+step "3/5  restart palace-daemon on $HOST"
+ssh "$HOST" "systemctl --user restart palace-daemon" || fail "restart failed"
+ok "restart issued"
+
+step "4/5  wait for daemon health"
+deadline=$((SECONDS + HEALTH_TIMEOUT))
+while (( SECONDS < deadline )); do
+    if curl -fs --max-time 3 "$URL/health" >/dev/null 2>&1; then
+        version=$(curl -s "$URL/health" | python3 -c 'import sys,json; print(json.load(sys.stdin)["version"])' 2>/dev/null || echo "?")
+        ok "healthy on v$version (after $((SECONDS - (deadline - HEALTH_TIMEOUT)))s)"
+        break
+    fi
+    sleep 1
+done
+(( SECONDS >= deadline )) && fail "daemon did not respond on $URL within ${HEALTH_TIMEOUT}s"
+
+step "5/5  smoke-test routes"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+PALACE_DAEMON_URL="$URL" PALACE_API_KEY="$KEY" \
+    bash "$SCRIPT_DIR/verify-routes.sh" \
+    || fail "verify-routes reported failures (see output above)"
+
+printf '\n\033[1;32m✦ deploy complete: %s on %s\033[0m\n' "$local_sha" "$URL"

--- a/scripts/purge_wings.py
+++ b/scripts/purge_wings.py
@@ -18,8 +18,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
-PALACE_PATH = Path.home() / ".mempalace" / "palace"
-DB_PATH = PALACE_PATH / "chroma.sqlite3"
+_DEFAULT_PALACE = Path.home() / ".mempalace" / "palace"
 
 
 def get_embedding_ids(db: sqlite3.Connection, wing: str) -> list[int]:
@@ -92,7 +91,12 @@ def main():
     parser = argparse.ArgumentParser(description="Offline wing purge (daemon must be stopped)")
     parser.add_argument("wings", nargs="+", help="Wing names to purge")
     parser.add_argument("--dry-run", action="store_true", help="Count only, no deletion")
+    parser.add_argument("--palace", type=Path, default=_DEFAULT_PALACE, help="Path to palace directory")
     args = parser.parse_args()
+
+    global PALACE_PATH, DB_PATH
+    PALACE_PATH = args.palace
+    DB_PATH = PALACE_PATH / "chroma.sqlite3"
 
     if not DB_PATH.exists():
         print(f"Database not found at {DB_PATH}", file=sys.stderr)

--- a/scripts/verify-routes.sh
+++ b/scripts/verify-routes.sh
@@ -74,6 +74,9 @@ probe "GET /context?kind=all" "results" "$URL/context?topic=palace-daemon&limit=
 # /stats — read-only summary across kg + graph + status tools.
 probe "GET /stats" "kg" "$URL/stats"
 
+# /graph — single-shot structural snapshot (v1.6.0).
+probe "GET /graph" '"wings"' "$URL/graph"
+
 # /repair/status — query state, no actual repair.
 probe_json_field "GET /repair/status" "in_progress" "$URL/repair/status"
 

--- a/scripts/verify-routes.sh
+++ b/scripts/verify-routes.sh
@@ -25,7 +25,7 @@ probe() {
   local expected="$2"
   shift 2
   local resp
-  resp=$(curl -sS --max-time 30 "${H_AUTH[@]}" "$@" 2>&1) || fail "$label — curl error"
+  resp=$(curl -sS --max-time 90 "${H_AUTH[@]}" "$@" 2>&1) || fail "$label — curl error"
   if echo "$resp" | grep -q "$expected"; then
     pass "$label"
   else
@@ -38,7 +38,7 @@ probe_json_field() {
   local field="$2"
   shift 2
   local val
-  val=$(curl -sS --max-time 30 "${H_AUTH[@]}" "$@" 2>&1 | python3 -c "
+  val=$(curl -sS --max-time 90 "${H_AUTH[@]}" "$@" 2>&1 | python3 -c "
 import json, sys
 try:
     d = json.load(sys.stdin)
@@ -78,7 +78,7 @@ probe "GET /stats" "kg" "$URL/stats"
 probe_json_field "GET /repair/status" "in_progress" "$URL/repair/status"
 
 # limit= is honored — proves the max_results→limit fix landed.
-COUNT=$(curl -sS --max-time 30 "${H_AUTH[@]}" "$URL/search?q=palace&limit=3&kind=all" \
+COUNT=$(curl -sS --max-time 90 "${H_AUTH[@]}" "$URL/search?q=palace&limit=3&kind=all" \
   | python3 -c "import json, sys; print(len(json.load(sys.stdin).get('results', [])))" 2>&1)
 if [ "$COUNT" = "3" ]; then
   pass "limit=3 returns 3 hits (max_results fix)"
@@ -89,9 +89,9 @@ else
 fi
 
 # Default kind=content excludes more drawers than kind=all.
-ALL=$(curl -sS --max-time 30 "${H_AUTH[@]}" "$URL/search?q=palace&limit=20&kind=all" \
+ALL=$(curl -sS --max-time 90 "${H_AUTH[@]}" "$URL/search?q=palace&limit=20&kind=all" \
   | python3 -c "import json, sys; d=json.load(sys.stdin); print(d.get('available_in_scope', 0))" 2>&1)
-CONTENT=$(curl -sS --max-time 30 "${H_AUTH[@]}" "$URL/search?q=palace&limit=20&kind=content" \
+CONTENT=$(curl -sS --max-time 90 "${H_AUTH[@]}" "$URL/search?q=palace&limit=20&kind=content" \
   | python3 -c "import json, sys; d=json.load(sys.stdin); print(d.get('available_in_scope', 0))" 2>&1)
 if [ "$ALL" -gt "$CONTENT" ] 2>/dev/null; then
   pass "kind=content scope ($CONTENT) < kind=all scope ($ALL) — checkpoint filter active"

--- a/scripts/verify-routes.sh
+++ b/scripts/verify-routes.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# verify-routes.sh — smoke test for palace-daemon HTTP routes after deploy.
+#
+# Exercises every public route against a running daemon. Designed to be
+# run manually after `systemctl --user restart palace-daemon` or
+# equivalent, not in CI (it depends on a live palace).
+#
+# Usage:
+#   PALACE_DAEMON_URL=http://disks.jphe.in:8085 \
+#   PALACE_API_KEY=... \
+#       scripts/verify-routes.sh
+
+set -e
+
+URL="${PALACE_DAEMON_URL:-http://localhost:8085}"
+KEY="${PALACE_API_KEY:-}"
+H_AUTH=()
+[ -n "$KEY" ] && H_AUTH=(-H "x-api-key: $KEY")
+
+pass() { echo "  ✓ $1"; }
+fail() { echo "  ✗ $1" >&2; exit 1; }
+
+probe() {
+  local label="$1"
+  local expected="$2"
+  shift 2
+  local resp
+  resp=$(curl -sS --max-time 30 "${H_AUTH[@]}" "$@" 2>&1) || fail "$label — curl error"
+  if echo "$resp" | grep -q "$expected"; then
+    pass "$label"
+  else
+    fail "$label — expected '$expected' in response: ${resp:0:200}"
+  fi
+}
+
+probe_json_field() {
+  local label="$1"
+  local field="$2"
+  shift 2
+  local val
+  val=$(curl -sS --max-time 30 "${H_AUTH[@]}" "$@" 2>&1 | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get('$field', ''))
+except Exception as e:
+    print(f'PARSE-ERROR:{e}', file=sys.stderr)
+" 2>&1)
+  if [ -n "$val" ] && [ "${val:0:13}" != "PARSE-ERROR:" ]; then
+    pass "$label ($field=$val)"
+  else
+    fail "$label — bad JSON or missing field: $val"
+  fi
+}
+
+echo "→ palace-daemon at $URL"
+echo
+
+# /health — no auth, should always respond.
+probe "GET /health" "palace-daemon" "$URL/health"
+
+# /search — verifies the kind= and limit= params are honored. Earlier
+# versions silently dropped limit (passed as max_results) and had no
+# kind= support.
+probe "GET /search (default kind=content)" "results" "$URL/search?q=palace-daemon&limit=2"
+probe "GET /search?kind=all" "results" "$URL/search?q=palace-daemon&limit=2&kind=all"
+probe "GET /search?kind=checkpoint" "results" "$URL/search?q=palace-daemon&limit=2&kind=checkpoint"
+probe "GET /search rejects bad kind" "must be one of" "$URL/search?q=x&kind=bogus"
+
+# /context — same code path with a different param name for LLM-friendly prompts.
+probe "GET /context (default kind=content)" "results" "$URL/context?topic=palace-daemon&limit=2"
+probe "GET /context?kind=all" "results" "$URL/context?topic=palace-daemon&limit=2&kind=all"
+
+# /stats — read-only summary across kg + graph + status tools.
+probe "GET /stats" "kg" "$URL/stats"
+
+# /repair/status — query state, no actual repair.
+probe_json_field "GET /repair/status" "in_progress" "$URL/repair/status"
+
+# limit= is honored — proves the max_results→limit fix landed.
+COUNT=$(curl -sS --max-time 30 "${H_AUTH[@]}" "$URL/search?q=palace&limit=3&kind=all" \
+  | python3 -c "import json, sys; print(len(json.load(sys.stdin).get('results', [])))" 2>&1)
+if [ "$COUNT" = "3" ]; then
+  pass "limit=3 returns 3 hits (max_results fix)"
+elif [ "$COUNT" = "0" ] || [ -z "$COUNT" ]; then
+  echo "  ? limit=3 returned 0 — palace may be empty or unreachable, can't confirm fix"
+else
+  fail "limit=3 returned $COUNT hits — expected 3 (or 0 on empty palace)"
+fi
+
+# Default kind=content excludes more drawers than kind=all.
+ALL=$(curl -sS --max-time 30 "${H_AUTH[@]}" "$URL/search?q=palace&limit=20&kind=all" \
+  | python3 -c "import json, sys; d=json.load(sys.stdin); print(d.get('available_in_scope', 0))" 2>&1)
+CONTENT=$(curl -sS --max-time 30 "${H_AUTH[@]}" "$URL/search?q=palace&limit=20&kind=content" \
+  | python3 -c "import json, sys; d=json.load(sys.stdin); print(d.get('available_in_scope', 0))" 2>&1)
+if [ "$ALL" -gt "$CONTENT" ] 2>/dev/null; then
+  pass "kind=content scope ($CONTENT) < kind=all scope ($ALL) — checkpoint filter active"
+elif [ "$ALL" = "0" ] || [ "$ALL" = "$CONTENT" ]; then
+  echo "  ? kind=content scope == kind=all scope ($CONTENT) — palace may have no checkpoints to filter"
+else
+  fail "kind=content scope ($CONTENT) >= kind=all scope ($ALL) — filter is not active"
+fi
+
+echo
+echo "✓ all routes verified"


### PR DESCRIPTION
Six changes from running palace-daemon. Happy to split into separate PRs if you'd prefer.

### `fix: warm ChromaDB client on startup, remove broken signal handlers` (2012f79)

ChromaDB's Rust HNSW binding can SIGSEGV on the first request when started cold. Pre-warming the client in the FastAPI lifespan (before yield) avoids this.

Also drops the custom asyncio signal handlers that called `sys.exit()` from inside an asyncio callback — this produced a `CancelledError`/`SystemExit` traceback on stop and skipped the lifespan shutdown flush. Uvicorn's built-in signal handling already does the right thing.

### `feat: add /repair, /silent-save endpoints and themed messages` (d2e867c)

- **`POST /repair`** with four modes: `light`, `scan`, `prune`, `rebuild`. Acquires `_exclusive_palace()` (all read/write/mine semaphores) for `rebuild`.
- **`POST /silent-save`** with double-checked locking around the repair flag. While a `/repair mode=rebuild` is in progress, saves are queued to a JSONL file at `<palace_parent>/palace-daemon-pending.jsonl` and drained automatically after the repair completes.
- **`messages.py`** with themed user-facing strings returned in `systemMessage`.

### `feat: add --palace flag to purge_wings.py` (34fee93)

Script hardcoded `~/.mempalace/palace`. `--palace <path>` lets it run against non-default deployments. Default unchanged.

### `fix(mcp-client): bump HTTP timeout 30s→120s, env-tunable` (352b25c)

The 30s default in `clients/mempalace-mcp.py` is too short for cold-start `mempalace_status` calls on large palaces (HNSW rebuild on a few hundred thousand drawers can take several minutes). Default raised to 120s, overridable via `PALACE_MCP_TIMEOUT`.

### `feat(clients): palace-mode CLI + fast-path hook + MCP dispatcher` (f8e0faa)

Three deployment helpers in `clients/`:
- **palace-mode**: shell CLI that flips between local (in-process) and remote (daemon) palace modes by toggling `PALACE_DAEMON_URL` in user settings. Subcommands: `status`, `local`, `remote [URL]`, `install` (idempotent re-apply after plugin updates), `verify`.
- **palace-mcp-dispatch.sh**: invoked by the plugin's MCP server command. Dispatches to `mempalace-mcp.py --daemon $URL` when `PALACE_DAEMON_URL` is set, otherwise falls back to in-process `python -m mempalace.mcp_server`.
- **mempal-fast.py**: stdlib-only Stop/PreCompact hook handler. POSTs to `/silent-save`. Imports no `mempalace`, loads no chromadb — so cold hook fires can't trigger the same SIGSEGV the warmup commit fixes for the daemon itself.

Conceptually separable from the daemon changes — happy to split this commit into a follow-up PR if you'd rather review the daemon work first. (Bundled here because it sits in `clients/` alongside the existing `mempalace-mcp.py`.)

### `fix: address Copilot review on PR #4 + tighten queue gating` (bd68632)

Pulled from Copilot's review of an earlier push:
- `/silent-save` queue gating now triggers on `mode == "rebuild"` only — `light`/`scan`/`prune` don't replace the collection, so saves can proceed normally during those.
- `_enqueue_pending_write` is now async + uses `asyncio.to_thread` so the disk append doesn't block the event loop under bursty enqueue load.
- `_drain_pending_writes` holds `_write_sem` per entry (matching the documented contract of `_do_silent_save_write`); failed entries are quarantined to a timestamped sibling so the next drain doesn't replay successful saves.
- `body["message_count"]` is parsed via try/except, returns 400 on non-integer input.
- `asyncio.get_event_loop()` → `asyncio.get_running_loop()` (deprecated in 3.12+ inside async functions).
- `PALACE_MCP_TIMEOUT` parse hardened in the proxy client — bad env value warns and falls back to 120s instead of crashing.