### PR TITLE
fix: honor `limit=` on /search and /context

### DIFF
--- a/main.py
+++ b/main.py
@@ -440,7 +440,7 @@ async def search(q: str, limit: int = 5, x_api_key: str | None = Header(default=
     result = await _call({
         "jsonrpc": "2.0", "id": 1,
         "method": "tools/call",
-        "params": {"name": "mempalace_search", "arguments": {"query": q, "max_results": limit}},
+        "params": {"name": "mempalace_search", "arguments": {"query": q, "limit": limit}},
     })
     return _unwrap(result)
 
@@ -452,7 +452,7 @@ async def context(topic: str, limit: int = 5, x_api_key: str | None = Header(def
     result = await _call({
         "jsonrpc": "2.0", "id": 1,
         "method": "tools/call",
-        "params": {"name": "mempalace_search", "arguments": {"query": topic, "max_results": limit}},
+        "params": {"name": "mempalace_search", "arguments": {"query": topic, "limit": limit}},
     })
     return _unwrap(result)
 


### PR DESCRIPTION
## Problem

Both `/search` and `/context` accept a `limit=` query parameter and forward it to the `mempalace_search` MCP tool, but the dict that gets passed uses the key `max_results`. The MCP tool's `input_schema` (in `mempalace.mcp_server`'s `TOOLS` dict) declares the parameter as `limit`, not `max_results`. `mempalace.mcp_server.handle_request` filters tool arguments through the schema-property whitelist and silently drops unknown keys, so `max_results` is dropped on every call and the tool falls back to its default `limit=5`.

Net effect: every `/search?q=…&limit=N` and `/context?topic=…&limit=N` response is capped at 5 hits regardless of what the caller asked for.

## Fix

Two-character rename per route: `"max_results": limit` → `"limit": limit`. The user-supplied value now binds.

## Confirmation

Against a running v1.5.1 daemon, before the fix:

```
$ curl -s 'http://localhost:8085/search?q=palace&limit=20' | jq '.results | length'
5
```

After:

```
$ curl -s 'http://localhost:8085/search?q=palace&limit=20' | jq '.results | length'
20
```

(when the palace has at least 20 matches; otherwise the natural result-count cap.)

## Scope

Two-line change in `main.py`. No new tests because the behavior depends on a live `mempalace_search` tool — the existing manual-smoke pattern is the natural verification path. Happy to add an end-to-end test if you'd like one against the test-double pattern other tests use.

Originally extracted from a larger fork-side commit (`b4b39fc`) that bundled this fix with other transitional changes; sending it standalone per the "small separate PRs" preference noted on PR #4.