### PR TITLE
feat: canonicalize Stop-hook topic at daemon boundary with warning log

### DIFF
--- a/main.py
+++ b/main.py
@@ -48,6 +48,17 @@ PALACE_MAX_CONCURRENCY = int(os.getenv("PALACE_MAX_CONCURRENCY", "4"))
 PALACE_MAX_READ_CONCURRENCY = int(os.getenv("PALACE_MAX_READ_CONCURRENCY", str(PALACE_MAX_CONCURRENCY)))
 PALACE_MAX_WRITE_CONCURRENCY = int(os.getenv("PALACE_MAX_WRITE_CONCURRENCY", str(max(1, PALACE_MAX_CONCURRENCY // 2))))
 
+# Canonical topic for Stop-hook auto-save checkpoint diary entries. Matches
+# the value already used in clients/hook.py and clients/mempal-fast.py, plus
+# mempalace's `tool_diary_write` topic-routing for the
+# `mempalace_session_recovery` collection (the structural fix for #1161-era
+# checkpoint domination of search results).
+CHECKPOINT_TOPIC = "checkpoint"
+# Legacy synonyms older clients may have written. `_canonical_topic()`
+# rewrites these at the daemon boundary with a warning log line so drift
+# is visible and the palace stays clean.
+CHECKPOINT_TOPIC_SYNONYMS = ("auto-save",)
+
 # Read ops: up to PALACE_MAX_READ_CONCURRENCY concurrent.
 # Write ops: up to PALACE_MAX_WRITE_CONCURRENCY concurrent.
 # Set PALACE_MAX_WRITE_CONCURRENCY=1 to serialise writes (mitigates MemPalace
@@ -290,6 +301,38 @@ async def _drain_pending_writes() -> int:
     return count
 
 
+def _canonical_topic(topic) -> str:
+    """Canonicalize a Stop-hook checkpoint topic at the daemon boundary.
+
+    Synonyms become ``CHECKPOINT_TOPIC`` with a warning log so client-side
+    drift is visible. Any other string is left as-is — the caller may have
+    legitimately used a non-checkpoint topic name on this diary write
+    (e.g. ``"musings"``, ``"decisions"``) and we shouldn't clobber that.
+
+    Non-string inputs (``None``, numbers, lists from a malformed JSON
+    payload) collapse to ``CHECKPOINT_TOPIC`` with a warning, rather than
+    leaking through to ``tool_diary_write`` and turning a bad client
+    request into an internal type error.
+
+    Defense in depth: the bundled clients already write the canonical
+    value; this rewrite catches future drift, third-party callers, or
+    buggy clients without rejecting the save outright.
+    """
+    if not isinstance(topic, str):
+        _log.warning(
+            "silent-save: non-string topic %r (%s); coercing to %r",
+            topic, type(topic).__name__, CHECKPOINT_TOPIC,
+        )
+        return CHECKPOINT_TOPIC
+    if topic in CHECKPOINT_TOPIC_SYNONYMS:
+        _log.warning(
+            "silent-save: rewriting non-canonical checkpoint topic %r → %r",
+            topic, CHECKPOINT_TOPIC,
+        )
+        return CHECKPOINT_TOPIC
+    return topic
+
+
 async def _do_silent_save_write(payload: dict) -> dict:
     """Write a diary checkpoint via tool_diary_write in an executor.
 
@@ -298,7 +341,7 @@ async def _do_silent_save_write(payload: dict) -> dict:
     """
     wing = payload.get("wing", "") or ""
     entry = payload.get("entry", "")
-    topic = payload.get("topic", "checkpoint")
+    topic = _canonical_topic(payload.get("topic", CHECKPOINT_TOPIC))
     agent_name = payload.get("agent_name", "session-hook")
     loop = asyncio.get_running_loop()
 

--- a/main.py
+++ b/main.py
@@ -301,7 +301,7 @@ async def _drain_pending_writes() -> int:
     return count
 
 
-def _canonical_topic(topic) -> str:
+def _canonical_topic(topic, *, caller: dict | None = None) -> str:
     """Canonicalize a Stop-hook checkpoint topic at the daemon boundary.
 
     Synonyms become ``CHECKPOINT_TOPIC`` with a warning log so client-side
@@ -317,17 +317,29 @@ def _canonical_topic(topic) -> str:
     Defense in depth: the bundled clients already write the canonical
     value; this rewrite catches future drift, third-party callers, or
     buggy clients without rejecting the save outright.
+
+    ``caller`` is an optional dict of identifying fields (``agent_name``,
+    ``wing``, ``session_id``) included verbatim in any warning log. Lets
+    operators trace a misbehaving client across many concurrent saves.
     """
+    ctx = ""
+    if caller:
+        # Compact, structured tail — only fields that actually have a
+        # value get included so an empty payload doesn't produce a
+        # verbose log.
+        bits = [f"{k}={v!r}" for k, v in caller.items() if v not in (None, "")]
+        if bits:
+            ctx = " (caller: " + ", ".join(bits) + ")"
     if not isinstance(topic, str):
         _log.warning(
-            "silent-save: non-string topic %r (%s); coercing to %r",
-            topic, type(topic).__name__, CHECKPOINT_TOPIC,
+            "silent-save: non-string topic %r (%s); coercing to %r%s",
+            topic, type(topic).__name__, CHECKPOINT_TOPIC, ctx,
         )
         return CHECKPOINT_TOPIC
     if topic in CHECKPOINT_TOPIC_SYNONYMS:
         _log.warning(
-            "silent-save: rewriting non-canonical checkpoint topic %r → %r",
-            topic, CHECKPOINT_TOPIC,
+            "silent-save: rewriting non-canonical checkpoint topic %r -> %r%s",
+            topic, CHECKPOINT_TOPIC, ctx,
         )
         return CHECKPOINT_TOPIC
     return topic
@@ -341,8 +353,15 @@ async def _do_silent_save_write(payload: dict) -> dict:
     """
     wing = payload.get("wing", "") or ""
     entry = payload.get("entry", "")
-    topic = _canonical_topic(payload.get("topic", CHECKPOINT_TOPIC))
     agent_name = payload.get("agent_name", "session-hook")
+    topic = _canonical_topic(
+        payload.get("topic", CHECKPOINT_TOPIC),
+        caller={
+            "agent_name": agent_name,
+            "wing": wing,
+            "session_id": payload.get("session_id"),
+        },
+    )
     loop = asyncio.get_running_loop()
 
     def _work():


### PR DESCRIPTION
## Summary

Adds `_canonical_topic()` between `/silent-save`'s payload parse and `tool_diary_write`. When a topic comes in matching a known legacy synonym (currently `\"auto-save\"`), it gets rewritten to the canonical `CHECKPOINT_TOPIC` (`\"checkpoint\"`) and a warning is logged. Non-checkpoint topics (e.g. `\"musings\"`, `\"decisions\"`) pass through unchanged.

## Why

The bundled clients (`clients/hook.py`, `clients/mempal-fast.py`) already write the canonical value, so this is defense-in-depth at the daemon boundary. It catches:

1. Future drift in those clients (someone edits one and forgets the convention)
2. Third-party callers POSTing to `/silent-save` directly with the older synonym
3. Buggy hook installs that haven't been updated

Without this, drift silently leaks into palace metadata. Mempalace's `tool_diary_write` topic-routing — which sends matching topics to a dedicated session-recovery collection rather than the searchable main collection — misses those drawers, and they end up dominating vector top-N in `mempalace_search` results.

The warning log makes drift observable so the operator can find the misbehaving client; the rewrite keeps the palace clean in the meantime.

## Scope

- New module-level constants: `CHECKPOINT_TOPIC`, `CHECKPOINT_TOPIC_SYNONYMS`
- New helper: `_canonical_topic(topic: str) -> str` (10 lines)
- One call-site change in `_do_silent_save_write`

`+33 / -1`. No new dependencies, no behavior change for already-canonical writes, no breaking change for callers using the default.

## Test plan

- Synonym path: POST `/silent-save` with `topic=\"auto-save\"` — expect successful diary write with topic stored as `\"checkpoint\"`, plus a warning log line `silent-save: rewriting non-canonical checkpoint topic 'auto-save' → 'checkpoint'`.
- Canonical path: POST with `topic=\"checkpoint\"` — expect no log line, normal save.
- Pass-through path: POST with `topic=\"musings\"` — expect no log line, topic stored as `\"musings\"`.

Originally extracted from a larger fork-side commit (`b4b39fc`) that bundled this with a now-retired `kind=` filter; sending it standalone per the \"small separate PRs\" preference noted on PR #4.