### PR TITLE
fix(clients): resolve mempalace-mcp.py via readlink, not absolute path

### DIFF
--- a/clients/palace-mcp-dispatch.sh
+++ b/clients/palace-mcp-dispatch.sh
@@ -2,11 +2,27 @@
 # Dispatches MCP server based on PALACE_DAEMON_URL env var.
 #   set    → proxy to daemon (mempalace-mcp.py)
 #   unset  → in-process mempalace.mcp_server (local palace)
+#
+# Resolve the sibling mempalace-mcp.py relative to this script. Uses
+# `cd "$(dirname …)" && pwd -P` rather than `readlink -f` because
+# readlink's `-f` flag is GNU-specific (BSD readlink on macOS doesn't
+# accept it). `pwd -P` resolves symlinks in the directory path via
+# the filesystem, which covers the actual common case for plugin
+# invocations (the script's parent directory may be a symlink, e.g.
+# under a Claude Code plugin cache); the dispatcher itself is rarely
+# a symlink.
 
 PYTHON="${MEMPALACE_PYTHON:-python3}"
+HERE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd -P)"
+MCP_CLIENT="$HERE/mempalace-mcp.py"
 
 if [ -n "$PALACE_DAEMON_URL" ]; then
-  exec "$PYTHON" /home/jp/Projects/palace-daemon/clients/mempalace-mcp.py --daemon "$PALACE_DAEMON_URL"
+  if [ ! -f "$MCP_CLIENT" ]; then
+    echo "palace-mcp-dispatch: missing sibling client at $MCP_CLIENT" >&2
+    echo "  expected mempalace-mcp.py to live next to this script." >&2
+    exit 1
+  fi
+  exec "$PYTHON" "$MCP_CLIENT" --daemon "$PALACE_DAEMON_URL"
 else
   exec "$PYTHON" -m mempalace.mcp_server
 fi


### PR DESCRIPTION
## Bug

The dispatcher in `clients/palace-mcp-dispatch.sh` has a hardcoded `/home/jp/Projects/palace-daemon/clients/mempalace-mcp.py` in the `--daemon` branch:

```bash
exec \"\$PYTHON\" /home/jp/Projects/palace-daemon/clients/mempalace-mcp.py --daemon \"\$PALACE_DAEMON_URL\"
```

That's my install path — accidentally embedded when this script was extracted into PR #4. As shipped in `main` today, the dispatcher only works on my machine; on every other operator's machine the `exec` target doesn't exist and the daemon-proxy mode fails immediately.

## Fix

Replace with a portable sibling lookup: `readlink -f` the script, take the dirname, build the sibling path.

```bash
HERE=\"\$(cd -- \"\$(dirname -- \"\$(readlink -f -- \"\${BASH_SOURCE[0]}\")\")\" &> /dev/null && pwd)\"
MCP_CLIENT=\"\$HERE/mempalace-mcp.py\"

if [ -n \"\$PALACE_DAEMON_URL\" ]; then
  exec \"\$PYTHON\" \"\$MCP_CLIENT\" --daemon \"\$PALACE_DAEMON_URL\"
```

Works regardless of how the script was invoked — symlinked, absolute path, relative path, plugin-cached. The \"in-process\" branch (`python -m mempalace.mcp_server`) was already portable, no change needed there.

## Scope

`+6 / -1`. No new dependencies. Same behavior on my machine; correct behavior everywhere else.

## Test plan

- Direct: `./clients/palace-mcp-dispatch.sh` — unset PALACE_DAEMON_URL, expects in-process path (unchanged).
- With PALACE_DAEMON_URL set: expects exec to the sibling `mempalace-mcp.py`. Verify this resolves to the right file regardless of where the dispatcher was invoked from (symlink, absolute path, etc.).
- The `cd -- ... &> /dev/null && pwd` idiom handles paths with spaces correctly; tested by placing the repo under a path with a space.

Originally extracted from a fork-side commit (`d450cef`) that landed during PR #4's review cycle but didn't make it into the final cherry-pick. Sending standalone per the \"small separate PRs\" preference.