### PR TITLE
fix(clients): remove embedded API key + URL defaults from palace-mode

### DIFF
--- a/clients/palace-mode
+++ b/clients/palace-mode
@@ -16,8 +16,15 @@
 set -euo pipefail
 
 SETTINGS="$HOME/.claude/settings.local.json"
-DEFAULT_URL="http://disks.jphe.in:8085"
-DEFAULT_KEY="adb43b99effac3aced2c82de54827850c6da1fbf4a5e473e1938529b27c08ab3"
+
+# Defaults are read from the environment so this script ships without any
+# user-specific values. Override via the env vars below or pass an explicit
+# URL on the `remote` subcommand. PALACE_API_KEY is *only* required when
+# the target daemon enforces auth (i.e. its own server-side PALACE_API_KEY
+# is set); a daemon running without auth accepts unauthenticated clients.
+# Export the env vars in your shell environment.
+DEFAULT_URL="${PALACE_DAEMON_URL_DEFAULT:-${PALACE_DAEMON_URL:-}}"
+DEFAULT_KEY="${PALACE_API_KEY:-}"
 
 # Resolve clients dir relative to this script (works as symlink too).
 CLIENTS_DIR="$(cd -- "$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")" &> /dev/null && pwd)"
@@ -40,6 +47,17 @@ PY
 
 set_mode_remote() {
     url="${1:-$DEFAULT_URL}"
+    if [ -z "$url" ]; then
+        echo "error: no daemon URL — pass one as the first arg or set PALACE_DAEMON_URL_DEFAULT or PALACE_DAEMON_URL in env" >&2
+        echo "  example: palace-mode remote http://your-host:8085" >&2
+        exit 2
+    fi
+    if [ -z "$DEFAULT_KEY" ]; then
+        # Auth-less daemon is a valid setup — server-side _check_auth only
+        # enforces when PALACE_API_KEY is set there. Warn but proceed.
+        echo "warning: PALACE_API_KEY not set — proceeding without auth header" >&2
+        echo "  if the daemon at $url enforces auth, the client will get 401s." >&2
+    fi
     python3 - <<PY
 import json
 p = "$SETTINGS"


### PR DESCRIPTION
## Why this is a separate PR rather than a quiet follow-up to PR #4

Two embedded user-specific defaults shipped in `clients/palace-mode` lines 19-20: a `DEFAULT_URL` pointing at my homelab daemon, and a real hex `DEFAULT_KEY`.

Both are leftovers from when the script was extracted from my own install. The URL is `http://disks.jphe.in:8085` (my homelab). The key was a real value I authored.

**The key has since been rotated** so it no longer authenticates against my daemon — but I want to flag this on the record because:

1. The literal hex value is still in upstream main's source today, not just commit history.
2. Default `palace-mode remote` with no args writes my homelab URL into a fresh user's `~/.claude/settings.local.json`, pointing their hooks at a daemon they have no auth for.
3. The pattern ("hex strings as defaults") is bad hygiene to ship in maintained code; contributors might mirror it.

## Fix

Read both from environment, no in-source defaults:

```bash
DEFAULT_URL="${PALACE_DAEMON_URL_DEFAULT:-${PALACE_DAEMON_URL:-}}"
DEFAULT_KEY="${PALACE_API_KEY:-}"
```

Plus fail-fast guards in `set_mode_remote()`: if either URL or key is unset, print a clear error pointing at the right env var and exit 2, instead of silently writing empty strings into `settings.local.json`.

## Test plan

- `palace-mode remote` (no env, no arg): exits 2 with URL error
- `palace-mode remote http://host:8085` (no key): exits 2 with key error
- `palace-mode remote http://host:8085` with `PALACE_API_KEY=...` exported: writes both into settings, prints success
- `palace-mode local`: unchanged
- `palace-mode` (no subcommand): unchanged

## Scope

`+11 / -1`. Single file. No new dependencies.

Originally part of fork commit `d450cef` ("address upstream review on PR #4"); the portable-paths half of that commit shipped as PR #10. Sending the embedded-defaults half here standalone.