### PR TITLE
chore(clients): add CHECKPOINT_TOPIC constant to mempal-fast.py

### DIFF
--- a/clients/mempal-fast.py
+++ b/clients/mempal-fast.py
@@ -7,6 +7,13 @@ from pathlib import Path
 SAVE_INTERVAL = 15
 STATE_DIR = Path.home() / ".mempalace" / "hook_state"
 
+# Canonical topic for Stop-hook auto-save checkpoint diary entries.
+# Matches the constant in clients/hook.py — both client paths must
+# write the same topic value so downstream readers (mempalace's
+# tool_diary_write topic-routing, any read-side filters) see a single
+# canonical name regardless of which client posted the save.
+CHECKPOINT_TOPIC = "checkpoint"
+
 
 def log(msg):
     try:
@@ -91,7 +98,7 @@ def main():
         "session_id": session_id,
         "wing": wing_from_path(transcript_path),
         "entry": f"Stop checkpoint at {count} exchanges",
-        "topic": "checkpoint",
+        "topic": CHECKPOINT_TOPIC,
         "agent_name": "session-hook",
         "themes": [],
         "message_count": since_last,


### PR DESCRIPTION
## Summary

Adds a `CHECKPOINT_TOPIC = \"checkpoint\"` constant at the top of `clients/mempal-fast.py` and replaces the inline `\"topic\": \"checkpoint\"` in `main()` with it.

## Why

`clients/hook.py` already declares this constant — see line 39 in current `main`:

```python
CHECKPOINT_TOPIC = \"checkpoint\"  # keep in sync with main.py and mempal-fast.py — used by kind= search filter
```

Both hook clients (`hook.py` and `mempal-fast.py`) write the same topic value to `tool_diary_write`. Centralizing it in a per-file constant keeps the canonical name in one place per client rather than scattered as inline strings, so a future rename only touches the two declarations.

The mempal-fast.py side just hadn't been brought into the same shape yet.

## Scope

`+8 / -1`. Single file. No behavior change — same string value gets posted, just sourced from a constant. No new dependencies.

Originally fork commit `dd8894c` (added the constants to both client files at once); that commit's hook.py half landed via PR #4's cherry-pick, the mempal-fast.py half didn't make it into the final cherry-pick. This brings them in line.