### PR TITLE
feat: GET /list — query-free metadata browse by wing/room

### DIFF
--- a/main.py
+++ b/main.py
@@ -457,6 +457,40 @@ async def context(topic: str, limit: int = 5, x_api_key: str | None = Header(def
     return _unwrap(result)
 
 
+@app.get("/list")
+async def list_drawers(
+    wing: str | None = None,
+    room: str | None = None,
+    limit: int = 20,
+    offset: int = 0,
+    x_api_key: str | None = Header(default=None),
+):
+    """List drawers by metadata (wing/room) — no search query required.
+
+    Wraps mempalace's ``mempalace_list_drawers`` MCP tool. Unlike /search,
+    this is an unranked listing pulled directly from sqlite metadata, so
+    it's the right path for browsing a wing without an embeddable query
+    (e.g. familiar's reflect-memories panel which wants "all drawers in
+    wing=reflect" sorted by recency).
+
+    Either ``wing`` or ``room`` (or both) should be supplied; with neither,
+    returns the first ``limit`` drawers across the whole palace, ordered
+    by mempalace's natural metadata-table order.
+    """
+    _check_auth(x_api_key)
+    args: dict = {"limit": int(limit), "offset": int(offset)}
+    if wing is not None:
+        args["wing"] = wing
+    if room is not None:
+        args["room"] = room
+    result = await _call({
+        "jsonrpc": "2.0", "id": 1,
+        "method": "tools/call",
+        "params": {"name": "mempalace_list_drawers", "arguments": args},
+    })
+    return _unwrap(result)
+
+
 @app.post("/memory")
 async def store_memory(request: Request, x_api_key: str | None = Header(default=None)):
     _check_auth(x_api_key)

--- a/main.py
+++ b/main.py
@@ -470,12 +470,16 @@ async def list_drawers(
     Wraps mempalace's ``mempalace_list_drawers`` MCP tool. Unlike /search,
     this is an unranked listing pulled directly from sqlite metadata, so
     it's the right path for browsing a wing without an embeddable query
-    (e.g. familiar's reflect-memories panel which wants "all drawers in
-    wing=reflect" sorted by recency).
+    (e.g. a "show me everything in wing=reflect" panel that just wants
+    a flat list, not a vector top-N).
 
-    Either ``wing`` or ``room`` (or both) should be supplied; with neither,
-    returns the first ``limit`` drawers across the whole palace, ordered
-    by mempalace's natural metadata-table order.
+    Ordering is whatever ``mempalace_list_drawers`` returns — currently
+    the natural sqlite metadata-table order, which approximates insertion
+    order but is not guaranteed to be strictly chronological. Pass
+    ``limit`` / ``offset`` for pagination.
+
+    Either ``wing`` or ``room`` (or both) can be supplied; with neither,
+    returns the first ``limit`` drawers across the whole palace.
     """
     _check_auth(x_api_key)
     args: dict = {"limit": int(limit), "offset": int(offset)}


### PR DESCRIPTION
Adds a small REST endpoint that wraps `mempalace_list_drawers` so consumers can enumerate drawers in a wing/room without inventing a search query.

## Why

`/search` with a `wing` filter quietly falls back to BM25 when the query has no embeddable content, and BM25 doesn't honour the wing filter — so a UI that wants "show me everything in wing=reflect" can't reliably get there through `/search`. `mempalace_list_drawers` already does the right thing at the metadata layer; this just exposes it over HTTP so a frontend doesn't have to talk MCP just to browse.

## Shape

```
GET /list?wing=reflect&room=summaries&limit=20&offset=0
```

- Either `wing` or `room` (or both) can be supplied; with neither, returns the first `limit` drawers across the whole palace, ordered by mempalace's natural metadata-table order.
- Pagination via `limit` / `offset` — same shape as `mempalace_list_drawers`.
- Authenticated via `X-Api-Key` header on the same code path as every other endpoint.

## Why it's safe

- Read-only — uses the read semaphore, never the write one.
- No new mempalace dependency: `mempalace_list_drawers` has been in mempalace 3.x since before the daemon's first release. The endpoint just forwards arguments.
- 34 lines of `main.py` and nothing else (the verify-routes.sh probe is held back because that file is being added in #9 — happy to fold it in there if you'd prefer, or send a follow-up after #9 lands).

Tested in production on the canonical 151K-drawer palace since 2026-04-26 — used by a small reflect-memories UI that needs the wing-scoped listing.

Glad to adjust the response shape, naming, or scope. Thanks for taking a look!