### PR TITLE
feat: DELETE /memory/{id} + PATCH /memory/{id}

### DIFF
--- a/main.py
+++ b/main.py
@@ -471,13 +471,29 @@ async def delete_memory(drawer_id: str, x_api_key: str | None = Header(default=N
 
 @app.patch("/memory/{drawer_id}")
 async def update_memory(drawer_id: str, request: Request, x_api_key: str | None = Header(default=None)):
-    """Update a drawer's content/wing/room. Wraps mempalace_update_drawer."""
+    """Update a drawer's content/wing/room. Wraps mempalace_update_drawer.
+
+    Body keys (all optional, but at least one is required): ``content``,
+    ``wing``, ``room``. Only supplied keys are forwarded to the underlying
+    tool. An empty body returns 400 — that's an ambiguous no-op rather
+    than something we should silently let through to mempalace.
+    """
     _check_auth(x_api_key)
-    body = await request.json()
+    try:
+        body = await request.json()
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail="Request body must be valid JSON.") from exc
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="Request body must be a JSON object.")
     args: dict = {"drawer_id": drawer_id}
     if "content" in body: args["content"] = body["content"]
     if "wing" in body: args["wing"] = body["wing"]
     if "room" in body: args["room"] = body["room"]
+    if len(args) == 1:
+        raise HTTPException(
+            status_code=400,
+            detail="PATCH /memory/{id} requires at least one of: content, wing, room.",
+        )
     result = await _call({
         "jsonrpc": "2.0", "id": 1,
         "method": "tools/call",

--- a/main.py
+++ b/main.py
@@ -505,7 +505,14 @@ async def update_memory(drawer_id: str, request: Request, x_api_key: str | None 
 @app.post("/memory")
 async def store_memory(request: Request, x_api_key: str | None = Header(default=None)):
     _check_auth(x_api_key)
-    body = await request.json()
+    # Same guards as PATCH /memory/{id} — malformed/empty JSON or
+    # non-object payloads should fail with 400, not propagate as 500.
+    try:
+        body = await request.json()
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail="Request body must be valid JSON.") from exc
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="Request body must be a JSON object.")
     content = body.get("content", "")
     wing = body.get("wing", "general")
     room = body.get("room", "notes")

--- a/main.py
+++ b/main.py
@@ -457,6 +457,35 @@ async def context(topic: str, limit: int = 5, x_api_key: str | None = Header(def
     return _unwrap(result)
 
 
+@app.delete("/memory/{drawer_id}")
+async def delete_memory(drawer_id: str, x_api_key: str | None = Header(default=None)):
+    """Delete a drawer by id. Wraps mempalace_delete_drawer."""
+    _check_auth(x_api_key)
+    result = await _call({
+        "jsonrpc": "2.0", "id": 1,
+        "method": "tools/call",
+        "params": {"name": "mempalace_delete_drawer", "arguments": {"drawer_id": drawer_id}},
+    })
+    return _unwrap(result)
+
+
+@app.patch("/memory/{drawer_id}")
+async def update_memory(drawer_id: str, request: Request, x_api_key: str | None = Header(default=None)):
+    """Update a drawer's content/wing/room. Wraps mempalace_update_drawer."""
+    _check_auth(x_api_key)
+    body = await request.json()
+    args: dict = {"drawer_id": drawer_id}
+    if "content" in body: args["content"] = body["content"]
+    if "wing" in body: args["wing"] = body["wing"]
+    if "room" in body: args["room"] = body["room"]
+    result = await _call({
+        "jsonrpc": "2.0", "id": 1,
+        "method": "tools/call",
+        "params": {"name": "mempalace_update_drawer", "arguments": args},
+    })
+    return _unwrap(result)
+
+
 @app.post("/memory")
 async def store_memory(request: Request, x_api_key: str | None = Header(default=None)):
     _check_auth(x_api_key)


### PR DESCRIPTION
Adds two small REST endpoints that wrap `mempalace_delete_drawer` and `mempalace_update_drawer`. Both tools have been in mempalace since 3.x — this just exposes them over HTTP so consumers can curate write-side outputs without going through MCP.

## Shape

```
DELETE /memory/{drawer_id}                         -> mempalace_delete_drawer
PATCH  /memory/{drawer_id}  {content?, wing?, room?}  -> mempalace_update_drawer
```

- PATCH body keys are all optional; only supplied fields are forwarded. So `PATCH /memory/abc {"content": "..."}` updates content and leaves wing/room alone.
- Both go through the write semaphore on the same code path as `/silent-save` (so they coordinate with `/repair mode=rebuild` and don't race the rebuild swap).
- Auth via `X-Api-Key` header, same as every other endpoint.

## Why

A small reflect-memories curation UI on my side needed to drop bad drawers and fix typos in good ones. Doable through MCP, but adding HTTP made the frontend much simpler. Posting upstream because it generalises — any UI that wants to show a list and let the user fix entries probably wants the same shape.

## What's not in this PR

- `verify-routes.sh` probes for DELETE / PATCH are held back because that file is being added by #9. Happy to fold them into #9 or send a follow-up after #9 lands — whatever's simpler for you.
- No version bump, no README changes — kept tight.

29 lines of `main.py`, no other files touched. Tested in production on the canonical 151K-drawer palace since 2026-04-26.

Thanks for considering it!