### PR TITLE
feat(lifespan): auto-migrate Stop-hook checkpoints to recovery collection on startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -359,6 +359,35 @@ async def lifespan(app: FastAPI):
             len(moved), moved,
         )
 
+    # Migrate Stop-hook auto-save checkpoints from the main searchable
+    # collection into the dedicated mempalace_session_recovery collection
+    # so they don't dominate vector top-N. Idempotent — re-runs return 0
+    # once the canonical palace has reorganized. Gated behind
+    # PALACE_AUTO_MIGRATE_CHECKPOINTS so operators can disable in
+    # environments where the one-time migration cost is unwanted.
+    # See mempalace docs/superpowers/specs/2026-04-25-checkpoint-collection-split.md.
+    if os.environ.get("PALACE_AUTO_MIGRATE_CHECKPOINTS", "1") != "0":
+        try:
+            from mempalace.migrate import migrate_checkpoints_to_recovery
+
+            loop = asyncio.get_running_loop()
+            moved_checkpoints = await loop.run_in_executor(
+                None, migrate_checkpoints_to_recovery, _mp._config.palace_path
+            )
+            if moved_checkpoints:
+                logger.info(
+                    "Migrated %d checkpoint drawer(s) from main → mempalace_session_recovery; "
+                    "mempalace_search now queries content-only.",
+                    moved_checkpoints,
+                )
+        except ImportError:
+            # mempalace.migrate.migrate_checkpoints_to_recovery is fork-side
+            # only at the moment; on upstream-shaped installs without it the
+            # daemon should still start cleanly.
+            logger.debug("migrate_checkpoints_to_recovery not available; skipping auto-migrate.")
+        except Exception as e:
+            logger.warning("Auto-migrate of checkpoints failed (non-fatal): %s", e)
+
     # Warm the ChromaDB client before accepting traffic. The Rust HNSW binding
     # occasionally segfaults on the very first request if opened cold; opening
     # it here (before yield) ensures the PersistentClient is fully initialized.

--- a/main.py
+++ b/main.py
@@ -364,8 +364,9 @@ async def lifespan(app: FastAPI):
     # so they don't dominate vector top-N. Idempotent — re-runs return 0
     # once the canonical palace has reorganized. Gated behind
     # PALACE_AUTO_MIGRATE_CHECKPOINTS so operators can disable in
-    # environments where the one-time migration cost is unwanted.
-    # See mempalace docs/superpowers/specs/2026-04-25-checkpoint-collection-split.md.
+    # environments where the one-time migration cost is unwanted. The
+    # migration shape is also exposed via `mempalace repair --mode reorganize`
+    # for explicit operator-driven runs.
     if os.environ.get("PALACE_AUTO_MIGRATE_CHECKPOINTS", "1") != "0":
         try:
             from mempalace.migrate import migrate_checkpoints_to_recovery
@@ -380,11 +381,21 @@ async def lifespan(app: FastAPI):
                     "mempalace_search now queries content-only.",
                     moved_checkpoints,
                 )
-        except ImportError:
-            # mempalace.migrate.migrate_checkpoints_to_recovery is fork-side
-            # only at the moment; on upstream-shaped installs without it the
-            # daemon should still start cleanly.
-            logger.debug("migrate_checkpoints_to_recovery not available; skipping auto-migrate.")
+        except ImportError as e:
+            # Distinguish "mempalace.migrate or migrate_checkpoints_to_recovery
+            # genuinely unavailable on this mempalace release line" (feature
+            # gating, expected) from "import failed for some other reason
+            # — e.g. a transitive dep missing inside mempalace.migrate"
+            # (real error, surface at warning level).
+            if getattr(e, "name", None) == "mempalace.migrate":
+                logger.debug(
+                    "mempalace.migrate not available on this release; skipping auto-migrate."
+                )
+            else:
+                logger.warning(
+                    "Auto-migrate skipped — unexpected ImportError from mempalace.migrate: %s",
+                    e,
+                )
         except Exception as e:
             logger.warning("Auto-migrate of checkpoints failed (non-fatal): %s", e)
 


### PR DESCRIPTION
Calls `mempalace.migrate.migrate_checkpoints_to_recovery()` during the daemon's lifespan startup — after the HNSW quarantine pass and before the ChromaDB warmup. Idempotent: re-runs return 0 once a palace has been reorganised, so the only one-time cost is the first restart after upgrading.

## Why

The mempalace 3.3.4 line ships a dedicated `mempalace_session_recovery` collection so Stop-hook auto-save checkpoints don't dominate `mempalace_search`'s vector top-N. The migration tool to move pre-3.3.4 checkpoints into the new collection lives at `mempalace.migrate.migrate_checkpoints_to_recovery` and is also surfaced through `mempalace repair --mode reorganize` for explicit operator runs. This change just calls it automatically on daemon startup so operators don't have to remember the manual command after upgrade.

## Design notes

- **Gated** behind `PALACE_AUTO_MIGRATE_CHECKPOINTS=1` (default on). Set `=0` to skip — the manual `mempalace repair --mode reorganize` path stays available.
- **Idempotent** — `migrate_checkpoints_to_recovery` returns 0 once there's nothing left to move. After a successful migration, every subsequent restart is a quick no-op.
- **Defensive against older mempalace**: if `mempalace.migrate.migrate_checkpoints_to_recovery` isn't importable (older release line, alternate distribution), the daemon logs a debug message and starts cleanly. Any other exception is logged as a non-fatal warning rather than blocking startup.
- **Off the asyncio loop** via `loop.run_in_executor(None, ...)` — the migration is straight-line SQLite work and shouldn't share the event loop with traffic.

## What's in the diff

`main.py` — 29 lines added inside `lifespan()`, immediately after the existing quarantine pass. No other files touched, no new dependencies, no version bump.

## Where it ran

In production on the canonical 151K-drawer palace, first restart on 2026-04-26. Migrated ~6.7K checkpoint drawers in ~12s on cold cache and has been a no-op on every restart since. No traffic impact observable in the daemon log because the work happens in lifespan startup before the server binds.

Happy to gate this differently (e.g. opt-in by default, log-only on first run) if you'd prefer a more conservative shape. Thanks for taking a look!