### PR TITLE
fix(security): constant-time auth + X-API-Key in hook HTTP calls

### DIFF
--- a/clients/hook.py
+++ b/clients/hook.py
@@ -218,6 +218,14 @@ def _extract_messages(transcript_path: str, max_turns: int = 30) -> list:
     return turns[-max_turns:]
 
 
+def _auth_headers() -> dict:
+    """Return X-Api-Key header if PALACE_API_KEY is set, else empty dict."""
+    key = os.environ.get("PALACE_API_KEY", "")
+    if key:
+        return {"X-Api-Key": key}
+    return {}
+
+
 def _post_digest(daemon_url: str, session_id: str, agent_name: str,
                  harness: str, messages: list, exchange_count: int) -> bool:
     payload = {
@@ -233,7 +241,7 @@ def _post_digest(daemon_url: str, session_id: str, agent_name: str,
         req = urllib.request.Request(
             daemon_url.rstrip("/") + "/digest",
             data=data,
-            headers={"Content-Type": "application/json"},
+            headers={"Content-Type": "application/json", **_auth_headers()},
             method="POST",
         )
         with urllib.request.urlopen(req, timeout=5) as resp:
@@ -260,7 +268,7 @@ def _post_mcp(daemon_url: str, tool_name: str, params: dict) -> bool:
         req = urllib.request.Request(
             daemon_url.rstrip("/") + "/mcp",
             data=data,
-            headers={"Content-Type": "application/json"},
+            headers={"Content-Type": "application/json", **_auth_headers()},
             method="POST",
         )
         with urllib.request.urlopen(req, timeout=10) as resp:
@@ -276,7 +284,7 @@ def _post_mine(daemon_url: str, mine_dir: str, timeout: int = 60) -> bool:
         req = urllib.request.Request(
             daemon_url.rstrip("/") + "/mine",
             data=payload,
-            headers={"Content-Type": "application/json"},
+            headers={"Content-Type": "application/json", **_auth_headers()},
             method="POST",
         )
         with urllib.request.urlopen(req, timeout=timeout) as resp:

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ Roadmap:
 """
 import argparse
 import asyncio
+import hmac
 import json
 import logging
 import os
@@ -217,7 +218,9 @@ _READ_TOOLS = {
 
 def _check_auth(x_api_key: str | None):
     key = os.getenv("PALACE_API_KEY", "")
-    if key and x_api_key != key:
+    if not key:
+        return
+    if not x_api_key or not hmac.compare_digest(x_api_key, key):
         raise HTTPException(status_code=401, detail="Invalid API key")
 
 


### PR DESCRIPTION
## Summary

- **Constant-time auth comparison**: Replace `!=` with `hmac.compare_digest` in `_check_auth()` to prevent timing side-channel attacks on the API key. Also handles `x_api_key=None` gracefully.
- **X-API-Key in hook HTTP calls**: Add `_auth_headers()` helper to `clients/hook.py` that reads `PALACE_API_KEY` from env and injects the `X-Api-Key` header into `_post_digest`, `_post_mcp`, and `_post_mine` requests. Without this, hooks silently fail with 401 when auth is enabled.

## Files changed

- `main.py` — `import hmac`, rewrite `_check_auth()` (3 lines)
- `clients/hook.py` — `_auth_headers()` helper + merge into 3 POST functions

## Test plan

- [ ] Start daemon with `PALACE_API_KEY=test123`
- [ ] Verify hook_stop / hook_precompact succeed (previously 401)
- [ ] Verify invalid key still returns 401
- [ ] Verify no key configured → all requests pass through

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>