### PR TITLE
fix(hook): filter tool_result from exchange count + self-heal backward counter

### DIFF
--- a/clients/hook.py
+++ b/clients/hook.py
@@ -166,6 +166,14 @@ def _count_human_messages(transcript_path: str) -> int:
                             )
                             if "<command-message>" in text:
                                 continue
+                            # All-tool_result content is a tool roundtrip,
+                            # not a human exchange — skip.
+                            text_blocks = [
+                                b for b in content
+                                if isinstance(b, dict) and b.get("type") == "text"
+                            ]
+                            if not text_blocks:
+                                continue
                         count += 1
                     elif entry.get("type") == "event_msg":
                         payload = entry.get("payload", {})
@@ -350,6 +358,14 @@ def hook_stop(data: dict, harness: str):
             last_save = int(last_save_file.read_text().strip())
         except (ValueError, OSError):
             last_save = 0
+
+    if exchange_count < last_save:
+        _log(
+            f"Session {session_id}: rebased stale last_save "
+            f"({last_save} → {exchange_count}) — counter went backward, "
+            f"likely after a count-rule change"
+        )
+        last_save = exchange_count
 
     since_last = exchange_count - last_save
     last_save_ts = _read_last_save_ts(session_id)


### PR DESCRIPTION
## Summary

Two related fixes to `_count_human_messages()` and `hook_stop()` in `clients/hook.py`.

### 1. Filter tool_result roundtrips from exchange count

`_count_human_messages()` counts every user-role message, including `tool_result` roundtrips — messages where the content is a list of `{type: "tool_result", ...}` blocks. These are the model's tool outputs echoed back, not human exchanges. Counting them inflates the exchange count 5-10x, causing saves to trigger on every message instead of every N human exchanges.

**Fix**: When content is a list, check if it contains at least one `text`-type block. If all blocks are `tool_result`, skip the message.

### 2. Self-heal when exchange_count goes backward

After fix 1 tightens the counting rules, existing sessions have a saved `last_save` checkpoint of ~955 (inflated count) but the real count is now ~87. This makes `since_last = exchange_count - last_save` negative, which permanently wedges all three save triggers (they all require `since_last > 0`).

**Fix**: Before computing `since_last`, check if `exchange_count < last_save`. If so, log the rebase and set `last_save = exchange_count`. The next real exchange resumes normal trigger behavior.

## Files changed

- `clients/hook.py` — 16 insertions

## Test plan

- [ ] Verify exchange count drops from inflated value (e.g. 955 → ~87) after update
- [ ] Verify first hook_stop after update logs the rebase and saves normally
- [ ] Verify subsequent saves trigger at correct intervals

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>