### PR TITLE
fix(repair): clear client cache before rebuild_index to prevent SQLite deadlock

### DIFF
--- a/main.py
+++ b/main.py
@@ -1366,9 +1366,11 @@ async def repair(request: Request, x_api_key: str | None = Header(default=None))
             async with _exclusive_palace():
                 loop = asyncio.get_running_loop()
                 palace_path = _mp._config.palace_path
-                await loop.run_in_executor(None, _mp_repair.rebuild_index, palace_path)
+                # Drop the cached PersistentClient + collection BEFORE
+                # rebuild_index opens its own, to avoid SQLite lock contention.
                 _mp._client_cache = None
                 _mp._collection_cache = None
+                await loop.run_in_executor(None, _mp_repair.rebuild_index, palace_path)
                 result = {"rebuilt": True}
             await _warn_if_hnsw_threads_unset()
 


### PR DESCRIPTION
## Summary

In the `/repair` endpoint's `mode == "rebuild"` branch, the daemon clears `_mp._client_cache` and `_mp._collection_cache` **after** `rebuild_index()`. But `rebuild_index()` internally creates a new `PersistentClient` against the same `palace_path`. If the daemon's cached client still holds a lock on the SQLite database, the new client deadlocks.

**Fix**: Move the two cache-clear lines to execute **before** `rebuild_index()`.

## Files changed

- `main.py` — 3 insertions, 1 deletion (4-line diff)

## Test plan

- [ ] `POST /repair?mode=rebuild` completes without hanging
- [ ] After rebuild, `/search` and `/health` work normally
- [ ] `/repair/status` shows `in_progress: false` after completion

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>