### PR TITLE
fix(/mine): backend-aware guard against concurrent ChromaDB client (#29)

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,6 +52,11 @@ API_KEY = os.getenv("PALACE_API_KEY", "")  # read at startup for argparse defaul
 PALACE_MAX_CONCURRENCY = int(os.getenv("PALACE_MAX_CONCURRENCY", "4"))
 PALACE_MAX_READ_CONCURRENCY = int(os.getenv("PALACE_MAX_READ_CONCURRENCY", str(PALACE_MAX_CONCURRENCY)))
 PALACE_MAX_WRITE_CONCURRENCY = int(os.getenv("PALACE_MAX_WRITE_CONCURRENCY", str(max(1, PALACE_MAX_CONCURRENCY // 2))))
+# Optional settle margin after the deterministic chroma client close in the
+# /mine lock-and-reopen choreography. close_palace() releases chromadb's
+# Rust-side SQLite file lock synchronously, so 0.0 is correct for normal
+# palaces; this is only a safety knob for very large palaces. (#29)
+PALACE_CHROMA_FLUSH_SECONDS = float(os.getenv("PALACE_CHROMA_FLUSH_SECONDS", "0.0"))
 
 # Canonical topic for Stop-hook auto-save checkpoint diary entries. Matches
 # the value already used in clients/hook.py and clients/mempal-fast.py, plus
@@ -227,6 +232,31 @@ def _sem_for(request_dict: dict) -> asyncio.Semaphore:
         return _read_sem
     tool_name = request_dict.get("params", {}).get("name", "")
     return _read_sem if tool_name in _READ_TOOLS else _write_sem
+
+
+def _drop_chroma_client(close: bool = True) -> None:
+    """Drop the daemon's chroma client caches; optionally release the Rust lock.
+
+    Both the mcp-local caches (``_client_cache``/``_collection_cache``) and the
+    pooled ``ChromaBackend._clients`` handle reference the same PersistentClient,
+    so dropping the caches alone does not release chromadb's Rust-side SQLite
+    file lock — that lock is held until ``PersistentClient.close()`` runs.
+
+    close=True routes the release through ``close_palace()`` (→ ``_close_client()``
+    → ``client.close()``) for a *deterministic* lock release. This is required
+    before handing the palace to an external writer (the /mine subprocess): a
+    bare cache drop would leave the daemon's stale client locking the path when
+    the subprocess opens its own client, reproducing the dual-client log-store
+    corruption this guards against (#29).
+
+    close=False keeps the legacy cache-only drop for callers where the process
+    is exiting and the OS reclaims the lock regardless.
+    """
+    _mp._collection_cache = None
+    _mp._client_cache = None
+    if close:
+        from mempalace.palace import get_backend
+        get_backend("chroma").close_palace(_mp._config.palace_path)
 
 
 async def _auto_repair():
@@ -1118,13 +1148,46 @@ async def mine(request: Request, x_api_key: str | None = Header(default=None)):
     if limit:
         cmd += ["--limit", str(limit)]
 
-    async with _mine_sem:
+    async def _run_mine_subprocess():
         proc = await asyncio.create_subprocess_exec(
             *cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
         stdout, stderr = await proc.communicate()
+        return proc, stdout, stderr
+
+    backend = getattr(_mp._config, "backend", "chroma")
+    if backend == "chroma":
+        # Two PersistentClient instances on one chroma path corrupt the Rust
+        # log store, in- or cross-process (#29). The mine subprocess opens its
+        # own client, so we make it the *sole* client for the job's duration:
+        # hold every slot so no daemon-mediated work races the mine, then
+        # deterministically close our client to release the Rust file lock.
+        # The reopen lives in finally so the daemon's client is always restored
+        # before another request can acquire a slot — even if the mine fails.
+        async with _exclusive_palace():
+            _drop_chroma_client(close=True)
+            if PALACE_CHROMA_FLUSH_SECONDS > 0:
+                await asyncio.sleep(PALACE_CHROMA_FLUSH_SECONDS)
+            try:
+                proc, stdout, stderr = await _run_mine_subprocess()
+            finally:
+                loop = asyncio.get_running_loop()
+                try:
+                    await loop.run_in_executor(None, _mp._get_collection, True)
+                except Exception as e:
+                    # Caches stay None → next request lazily reopens (self-heal).
+                    _log.critical(
+                        "POST /mine: failed to reopen palace client after mine "
+                        "(dir=%s) — next request will lazily reopen: %s",
+                        directory, e,
+                    )
+    else:
+        # postgres handles concurrent connections natively — the dual-client
+        # corruption cannot occur, so keep the original lightweight path.
+        async with _mine_sem:
+            proc, stdout, stderr = await _run_mine_subprocess()
 
     return {
         "returncode": proc.returncode,

--- a/tests/test_mine_backend_aware.py
+++ b/tests/test_mine_backend_aware.py
@@ -1,0 +1,156 @@
+"""Tests for the backend-aware /mine guard (#29).
+
+On the chroma backend, /mine must wrap the mine subprocess in the
+lock-and-reopen choreography: enter ``_exclusive_palace()``, drop+close
+the daemon's client (``_drop_chroma_client(close=True)``), spawn the
+subprocess, then reopen via ``_mp._get_collection(True)`` in a finally.
+On postgres it must keep the original lightweight path — no exclusive
+lock, no client close — because postgres tolerates concurrent clients.
+
+These invoke the ``mine()`` handler coroutine directly with a mocked
+Request and a mocked backend; the subprocess is stubbed by patching
+``asyncio.create_subprocess_exec``. No live daemon or palace required.
+
+Run with::
+
+    python -m unittest tests.test_mine_backend_aware -v
+"""
+import asyncio
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch, AsyncMock, MagicMock
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+import main  # noqa: E402
+
+
+class _FakeExclusive:
+    """Stand-in for _exclusive_palace() that records whether it was entered,
+    without touching the real semaphores."""
+
+    def __init__(self):
+        self.entered = False
+        self.exited = False
+
+    async def __aenter__(self):
+        self.entered = True
+        return self
+
+    async def __aexit__(self, *exc):
+        self.exited = True
+        return False
+
+
+def _fake_subprocess_factory(returncode=0, stdout=b"mined 3 drawers", stderr=b""):
+    async def _spawn(*args, **kwargs):
+        proc = MagicMock()
+        proc.communicate = AsyncMock(return_value=(stdout, stderr))
+        proc.returncode = returncode
+        return proc
+    return _spawn
+
+
+class TestMineBackendAware(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        # A real directory so the handler's is_absolute/exists/is_dir checks pass.
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = self.tmp.name
+
+        self._patches = [
+            patch.object(main, "_check_auth", side_effect=lambda *_a, **_k: None),
+        ]
+        for p in self._patches:
+            p.start()
+
+    async def asyncTearDown(self):
+        for p in self._patches:
+            p.stop()
+        self.tmp.cleanup()
+
+    def _request(self, **body_overrides):
+        body = {"dir": self.dir, "wing": "general", "mode": "convos"}
+        body.update(body_overrides)
+        req = MagicMock()
+        req.json = AsyncMock(return_value=body)
+        return req
+
+    async def test_chroma_enters_exclusive_closes_and_reopens(self):
+        fake_excl = _FakeExclusive()
+        fake_cfg = MagicMock(backend="chroma", palace_path="/tmp/palace")
+        with patch.object(main._mp, "_config", fake_cfg), \
+             patch.object(main, "_exclusive_palace", lambda: fake_excl), \
+             patch.object(main, "_drop_chroma_client") as drop, \
+             patch.object(main._mp, "_get_collection") as reopen, \
+             patch("asyncio.create_subprocess_exec",
+                   side_effect=_fake_subprocess_factory()) as spawn:
+            result = await main.mine(self._request(), x_api_key=None)
+
+        self.assertTrue(fake_excl.entered, "chroma must hold the exclusive palace lock")
+        self.assertTrue(fake_excl.exited)
+        drop.assert_called_once_with(close=True)
+        spawn.assert_called_once()
+        reopen.assert_called_once_with(True)
+        self.assertEqual(result["returncode"], 0)
+
+    async def test_postgres_keeps_lightweight_path(self):
+        fake_excl = _FakeExclusive()
+        fake_cfg = MagicMock(backend="postgres", palace_path="/tmp/palace")
+        with patch.object(main._mp, "_config", fake_cfg), \
+             patch.object(main, "_exclusive_palace", lambda: fake_excl), \
+             patch.object(main, "_drop_chroma_client") as drop, \
+             patch.object(main._mp, "_get_collection") as reopen, \
+             patch("asyncio.create_subprocess_exec",
+                   side_effect=_fake_subprocess_factory()) as spawn:
+            result = await main.mine(self._request(), x_api_key=None)
+
+        self.assertFalse(fake_excl.entered, "postgres must NOT hold the exclusive lock")
+        drop.assert_not_called()
+        reopen.assert_not_called()
+        spawn.assert_called_once()
+        self.assertEqual(result["returncode"], 0)
+
+    async def test_chroma_reopens_even_when_mine_fails(self):
+        """The reopen lives in a finally — a non-zero subprocess exit must
+        still restore the daemon's client."""
+        fake_excl = _FakeExclusive()
+        fake_cfg = MagicMock(backend="chroma", palace_path="/tmp/palace")
+        with patch.object(main._mp, "_config", fake_cfg), \
+             patch.object(main, "_exclusive_palace", lambda: fake_excl), \
+             patch.object(main, "_drop_chroma_client") as drop, \
+             patch.object(main._mp, "_get_collection") as reopen, \
+             patch("asyncio.create_subprocess_exec",
+                   side_effect=_fake_subprocess_factory(returncode=1, stdout=b"", stderr=b"boom")):
+            result = await main.mine(self._request(), x_api_key=None)
+
+        drop.assert_called_once_with(close=True)
+        # Reopen lives in a finally — must fire even though the mine failed.
+        reopen.assert_called_once_with(True)
+        self.assertEqual(result["returncode"], 1)
+
+    async def test_chroma_self_heals_when_reopen_throws(self):
+        """If the reopen itself throws, the handler must not crash — caches
+        stay None and the next request lazily reopens. The mine result is
+        still returned."""
+        fake_excl = _FakeExclusive()
+        fake_cfg = MagicMock(backend="chroma", palace_path="/tmp/palace")
+        with patch.object(main._mp, "_config", fake_cfg), \
+             patch.object(main, "_exclusive_palace", lambda: fake_excl), \
+             patch.object(main, "_drop_chroma_client"), \
+             patch.object(main._mp, "_get_collection", side_effect=RuntimeError("reopen boom")), \
+             patch("asyncio.create_subprocess_exec",
+                   side_effect=_fake_subprocess_factory()):
+            result = await main.mine(self._request(), x_api_key=None)
+
+        # Handler swallows the reopen failure (logged CRITICAL) and returns.
+        self.assertEqual(result["returncode"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Makes `POST /mine` backend-aware so it can no longer corrupt the chroma log store (#29).

`/mine` spawns `mempalace mine` as a subprocess that opens its **own** ChromaDB `PersistentClient` on the palace path while the daemon already holds one. Two `PersistentClient` instances on one path corrupt the Rust log store (in- or cross-process), so the mine silently persists zero drawers and recovery needs `mempalace repair`.

On **chroma**, the subprocess is now wrapped in a lock-and-reopen choreography so only one client ever touches the files:

1. Enter `_exclusive_palace()` — hold every read/write/mine slot (the primitive already used for `/repair` rebuild) so no daemon-mediated work races the mine.
2. `_drop_chroma_client(close=True)` — drop the mcp-local caches **and** `close_palace()` the pooled handle, releasing chromadb's Rust-side SQLite file lock *synchronously*. This must `close()`, not merely pop the client dict — a bare pop leaves the stale handle holding the lock until GC, reproducing the very corruption being fixed.
3. Run the subprocess as the **sole** client.
4. Reopen via `_get_collection(True)` in a `finally`, so the daemon's client is always restored — even if the mine exits non-zero. If the reopen itself throws, caches stay `None` and the next request lazily reopens (self-heal); logged `CRITICAL`.

On **postgres**, concurrent connections are native, so the original lightweight `_mine_sem` path is kept unchanged.

`PALACE_CHROMA_FLUSH_SECONDS` (default `0.0`) is an optional post-close settle margin for very large palaces; `close_palace()` is the mechanism, not the sleep.

## Validation (2026-05-27, chromadb 1.5.8)

- **Fix path — PASS.** Held a daemon-style client → `close_palace()` → ran a real `mempalace mine` subprocess → reopened via `get_collection` → read. Drawers persisted (2 → 4) and the collection stayed readable.
- **Reproducibility note.** On chromadb **1.5.8** the dual-client corruption did **not** reproduce — holding the client open across the mine, and a direct two-`PersistentClient` interleaved-write probe, both read cleanly. The corruption is **version-specific** to the chroma 1.x build originally hit. The guard therefore lands as **correct defense-in-depth**: harmless where the window is tolerated, load-bearing where it isn't. (Full detail in the issue thread; happy to pin the repro to the exact version you hit.)

## Test plan

- [x] `tests/test_mine_backend_aware.py` — chroma enters exclusive + closes + reopens; postgres keeps the lightweight path; reopen fires in `finally` on mine failure; handler self-heals when reopen throws. All green.
- [x] `main.py` syntax check + targeted suite pass against this base.

## Related `mempalace` issues

- **#261** — injectable backend for `miner.mine()`; the substrate change that would replace this subprocess dance with true single-client in-process mining. This PR is the correct interim fix until then.
- **#262** — `_force_chroma_cache_reset()` pops the client dict without `close()`, leaking the Rust lock; this PR routes the release through `close_palace()` instead.

Closes #29.
