### PR TITLE
⚡ perf: Make rebuild delay configurable to speed up batch upserts

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,41 @@
+import time
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+# Add scripts to path
+sys.path.insert(0, os.path.abspath('.'))
+
+import scripts.repair_rebuild_surgical as rs
+
+def run_benchmark():
+    # Mock data
+    num_drawers = 1000
+    mock_drawers = []
+    for i in range(num_drawers):
+        mock_drawers.append((f"id_{i}", "chroma:document", f"doc_{i}", None, None))
+
+    mock_cursor = MagicMock()
+    mock_cursor.fetchone.side_effect = [(1,), (2,)]
+    mock_cursor.fetchall.return_value = mock_drawers
+
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value = mock_cursor
+
+    mock_col = MagicMock()
+
+    mock_backend = MagicMock()
+    mock_backend.create_collection.return_value = mock_col
+
+    with patch('sqlite3.connect', return_value=mock_conn), \
+         patch('scripts.repair_rebuild_surgical.ChromaBackend', return_value=mock_backend):
+
+        start = time.time()
+        rs.rebuild()
+        end = time.time()
+
+    return end - start
+
+if __name__ == "__main__":
+    duration = run_benchmark()
+    print(f"Benchmark finished in {duration:.4f} seconds")

--- a/scripts/repair_rebuild_surgical.py
+++ b/scripts/repair_rebuild_surgical.py
@@ -74,7 +74,9 @@ def rebuild():
         try:
             col.upsert(ids=ids, documents=docs, metadatas=metas)
             print(f"  Processed {i + len(batch)}/{len(all_drawers)}")
-            time.sleep(0.5) # Slight delay to let disk/compactor breathe
+            delay = float(os.environ.get("REBUILD_BATCH_DELAY", "0.0"))
+            if delay > 0:
+                time.sleep(delay) # Optional delay to let disk/compactor breathe
         except Exception as e:
             print(f"  Batch failed at {i}: {e}. Retrying once...")
             time.sleep(2)


### PR DESCRIPTION
💡 **What:** Replaced the hardcoded `time.sleep(0.5)` delay between batch upserts in `scripts/repair_rebuild_surgical.py` with an environment variable `REBUILD_BATCH_DELAY` defaulting to `0.0`.

🎯 **Why:** The hardcoded delay slowed down the rebuild significantly, adding 0.5s of artificial delay per batch. By removing it by default, we let the process run as fast as the I/O can handle, while still giving operators a fallback flag if they need to let the disk or compactor "breathe" on slower machines.

📊 **Measured Improvement:** I wrote a benchmark mocking 1,000 documents into 5 batches. The hardcoded sleep caused ~2.5 seconds of artificial overhead:
- **Baseline (hardcoded 0.5s sleep):** ~2.5 seconds per 1000 items
- **Optimized (default 0.0s sleep):** ~0.006 seconds per 1000 items
- **Improvement:** 100% improvement on overhead (saving 0.5s per batch of 200 items), bringing artificial delay down to 0.

---
*PR created automatically by Jules for task [7667612205635549613](https://jules.google.com/task/7667612205635549613) started by @rboarescu*