### PR TITLE
🔒 Fix potential command injection vulnerability in `_clear_port`

### DIFF
--- a/main.py
+++ b/main.py
@@ -1662,8 +1662,13 @@ def _clear_port(port: int):
     """Attempt to kill any process currently holding the target port."""
     import subprocess
     try:
+        port = int(port)
+        if not (0 < port < 65536):
+            return
         # Use fuser to kill the process on the port.
         subprocess.run(["fuser", "-k", f"{port}/tcp"], capture_output=True)
+    except (ValueError, TypeError):
+        pass
     except Exception:
         pass
 

--- a/tests/test_clear_port.py
+++ b/tests/test_clear_port.py
@@ -1,0 +1,33 @@
+import pytest
+import subprocess
+from unittest.mock import patch
+from main import _clear_port
+
+@patch("subprocess.run")
+def test_clear_port_valid(mock_run):
+    _clear_port(8080)
+    mock_run.assert_called_once_with(["fuser", "-k", "8080/tcp"], capture_output=True)
+
+@patch("subprocess.run")
+def test_clear_port_valid_str(mock_run):
+    _clear_port("8080")
+    mock_run.assert_called_once_with(["fuser", "-k", "8080/tcp"], capture_output=True)
+
+@patch("subprocess.run")
+def test_clear_port_invalid_str(mock_run):
+    _clear_port("8080; echo 'hacked'")
+    mock_run.assert_not_called()
+
+@patch("subprocess.run")
+def test_clear_port_out_of_range_low(mock_run):
+    _clear_port(0)
+    mock_run.assert_not_called()
+    _clear_port(-10)
+    mock_run.assert_not_called()
+
+@patch("subprocess.run")
+def test_clear_port_out_of_range_high(mock_run):
+    _clear_port(65536)
+    mock_run.assert_not_called()
+    _clear_port(70000)
+    mock_run.assert_not_called()


### PR DESCRIPTION
🎯 **What:** The `_clear_port` function in `main.py` is vulnerable to command injection if passed untrusted data, because the `port` argument is directly interpolated into a `subprocess.run` array.
⚠️ **Risk:** Even though Python limits the blast radius of arguments passed to `subprocess.run` when `shell=False`, ensuring the input is an integer protects against unexpected evaluation inside `fuser` and defends against potential future use of `shell=True` or other tools. Command execution by untrusted input could lead to local host compromise.
🛡️ **Solution:** Explicitly cast `port` to `int` and validate it falls within the valid port range (0 < port < 65536) before calling `subprocess.run`. Handle `ValueError` and `TypeError` gracefully without calling the command. Tests were also added.

---
*PR created automatically by Jules for task [6870122984319804746](https://jules.google.com/task/6870122984319804746) started by @rboarescu*