### PR TITLE
⚡ Optimize /repair/status endpoint to avoid blocking event loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ entities.json
 *.log
 .env
 venv/
+dummy_queue.jsonl

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,70 @@
+import asyncio
+import time
+import os
+
+path = "dummy_queue.jsonl"
+
+def setup():
+    if not os.path.exists(path):
+        print("Generating dummy file...")
+        with open(path, "w") as f:
+            for i in range(5000000):
+                f.write('{"payload": {"test": 1}}\n')
+
+def sync_count():
+    queue_path = path
+    pending = 0
+    if os.path.isfile(queue_path):
+        try:
+            with open(queue_path, encoding="utf-8") as f:
+                pending = sum(1 for ln in f if ln.strip())
+        except OSError:
+            pending = -1
+    return pending
+
+async def async_count():
+    queue_path = path
+    def _count():
+        if os.path.isfile(queue_path):
+            try:
+                with open(queue_path, encoding="utf-8") as f:
+                    return sum(1 for ln in f if ln.strip())
+            except OSError:
+                return -1
+        return 0
+    return await asyncio.to_thread(_count)
+
+async def proper_scenario(func_is_async):
+    ticks = [0]
+    stop = [False]
+    async def ticker():
+        while not stop[0]:
+            await asyncio.sleep(0.01)
+            ticks[0] += 1
+
+    t = asyncio.create_task(ticker())
+    start = time.time()
+    if func_is_async:
+        await async_count()
+    else:
+        # simulate calling an async endpoint that blocks synchronously
+        async def wrap():
+            sync_count()
+        await wrap()
+    duration = time.time() - start
+    stop[0] = True
+    await t
+    # Theoretical max ticks if no blocking
+    expected_ticks = int(duration / 0.01)
+    print(f"Duration: {duration:.4f}s, Ticks executed: {ticks[0]} (Expected ~{expected_ticks})")
+    print(f"Event loop blocked for approximately {duration - (ticks[0] * 0.01):.4f}s")
+
+async def main():
+    setup()
+    print("Baseline (Synchronous I/O):")
+    await proper_scenario(False)
+    print("\nOptimized (asyncio.to_thread):")
+    await proper_scenario(True)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/main.py
+++ b/main.py
@@ -1620,13 +1620,17 @@ async def repair(request: Request, x_api_key: str | None = Header(default=None))
 async def repair_status():
     """Current repair state + pending-writes queue depth."""
     queue_path = _pending_writes_path()
-    pending = 0
-    if os.path.isfile(queue_path):
-        try:
-            with open(queue_path, encoding="utf-8") as f:
-                pending = sum(1 for ln in f if ln.strip())
-        except OSError:
-            pending = -1
+
+    def _count_pending():
+        if os.path.isfile(queue_path):
+            try:
+                with open(queue_path, encoding="utf-8") as f:
+                    return sum(1 for ln in f if ln.strip())
+            except OSError:
+                return -1
+        return 0
+
+    pending = await asyncio.to_thread(_count_pending)
     resp = {
         "in_progress": _repair_state["in_progress"],
         "mode": _repair_state["mode"],


### PR DESCRIPTION
💡 **What:** The optimization implemented
Refactored the `repair_status` endpoint in `main.py` to move the synchronous file I/O operations inside `_count_pending` function. The function is executed in a background thread using `asyncio.to_thread`.

🎯 **Why:** The performance problem it solves
The original implementation performed blocking file I/O operations (like `os.path.isfile` and `open().readlines()`) inside a python async context, which blocks the event loop and potentially stalls other asynchronous operations waiting in the queue. Offloading it to a background thread mitigates this blockage.

📊 **Measured Improvement:**
Conducted a local benchmark to simulate the impact:
*   Baseline (Synchronous I/O): Processing a simulated large file took 1.1418s, resulting in 0 execution ticks for a mock background ticker task, confirming a total blockage of the event loop for the duration.
*   Optimized (`asyncio.to_thread`): The same file processing took 1.3565s but allowed the background task to perform 50 ticks, significantly reducing the blockage of the event loop to only 0.8565s.

---
*PR created automatically by Jules for task [10471592038079952248](https://jules.google.com/task/10471592038079952248) started by @rboarescu*