### PR TITLE
🔒 Fix API key leak in /viz query parameter

### DIFF
--- a/main.py
+++ b/main.py
@@ -1064,10 +1064,7 @@ _VIZ_HTML_CACHE: str | None = None
 
 
 @app.get("/viz", response_class=HTMLResponse)
-async def viz(
-    key: str | None = None,
-    x_api_key: str | None = Header(default=None),
-):
+async def viz():
     """Self-contained status dashboard at /viz.
 
     Returns the HTML page from static/viz.html. The page then fetches
@@ -1075,12 +1072,10 @@ async def viz(
     KG force-graph (D3), wings bar chart, wing/room hierarchy (Mermaid),
     tunnels list, KG stats.
 
-    Auth: same as every other endpoint — ``X-Api-Key`` header. As an
-    ergonomic shortcut for browser bookmarking, ``?key=...`` is also
-    accepted; the page reads it from the URL and re-supplies it to the
-    data endpoints. The ``?key=...`` shape leaks the key into browser
-    history, proxy logs, and referer headers — prefer the header for
-    anything beyond a personal bookmark.
+    Auth: The HTML page itself is served unauthenticated. The client-side
+    JavaScript handles authentication for the data endpoints by prompting
+    the user for the API key (if required) and storing it in localStorage.
+    This avoids leaking the key in URLs, referer headers, or proxy logs.
 
     The HTML template is read from disk lazily on the first request and
     cached in-process thereafter (one disk read per daemon process).
@@ -1089,11 +1084,6 @@ async def viz(
     #431 (CLI stats), #256 (sync_status MCP), #601 (brief overview) — none
     cherry-picked, just patterns synthesized over the daemon's /graph.
     """
-    # Accept the API key from either the X-Api-Key header (preferred) or
-    # the ?key= query parameter (bookmarkable). _check_auth is a no-op
-    # when PALACE_API_KEY is unset, so this preserves the
-    # zero-config-local-dev experience.
-    _check_auth(x_api_key or key)
     global _VIZ_HTML_CACHE
     if _VIZ_HTML_CACHE is None:
         try:

--- a/static/viz.html
+++ b/static/viz.html
@@ -232,13 +232,9 @@ const PALETTE = {
 //------------------------------------------------------------------ params + auth
 const params = new URLSearchParams(location.search);
 const REFRESH_SECONDS = parseInt(params.get("refresh") || "0", 10);
-// `?key=...` is supported as a bookmarkable shortcut for the API key. This
-// is convenient but the key will appear in the browser's history, in any
-// referer header sent to a third-party origin, and in the access logs of
-// any forward proxy or reverse proxy on the path. **Do not use ?key= when
-// the dashboard might be screen-shared, screencast, or proxied through a
-// shared intermediary.** Prefer the `X-Api-Key` header for those cases.
-const KEY = params.get("key") || "";
+// Read the API key from localStorage. This avoids leaking the key via URLs,
+// browser history, or proxy logs.
+let KEY = localStorage.getItem("palace_api_key") || "";
 
 function withAuth(opts) {
   opts = opts || {};
@@ -248,7 +244,17 @@ function withAuth(opts) {
 }
 
 async function fetchJSON(path) {
-  const r = await fetch(path, withAuth());
+  let r = await fetch(path, withAuth());
+  if (r.status === 401) {
+    const inputKey = prompt("API Key required for " + path + ":");
+    if (inputKey !== null) {
+      KEY = inputKey.trim();
+      localStorage.setItem("palace_api_key", KEY);
+      r = await fetch(path, withAuth());
+    } else {
+      throw new Error("Authentication required for " + path);
+    }
+  }
   if (!r.ok) throw new Error(path + " → HTTP " + r.status);
   return r.json();
 }


### PR DESCRIPTION
🎯 **What:** The `/viz` endpoint accepted an API key via the `?key=` query parameter, which it passed to data endpoints.
⚠️ **Risk:** Query parameters are logged in web server logs, proxy logs, and saved in browser history, exposing the sensitive API key.
🛡️ **Solution:** The `/viz` HTML page is now served unauthenticated. The client-side JS attempts to fetch data endpoints and handles `401 Unauthorized` responses by prompting the user for an API key, storing it securely in `localStorage`, and retrying the request. This eliminates the need for URL-based authentication.

---
*PR created automatically by Jules for task [10351664004618334980](https://jules.google.com/task/10351664004618334980) started by @rboarescu*