### PR TITLE
feat(/search,/context): forward optional wing/room filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Added
+- **`/search` and `/context` accept optional `wing` and `room` filters** — both endpoints now forward `wing=` and `room=` query params into `mempalace_search` when supplied, mirroring the existing pass-through pattern on `/list`. When omitted the endpoints behave exactly as before, so existing clients are unaffected. Covers the common multi-tenant case where a caller wants to scope a semantic search to a single wing without filtering the result set client-side. Includes 7 unit tests (`tests/test_search_wing_filter.py`) covering back-compat + each filter combination.
+
 # Changelog — continued
 
 ## [1.8.1] - 2026-05-27

--- a/main.py
+++ b/main.py
@@ -715,24 +715,46 @@ async def health():
 
 
 @app.get("/search")
-async def search(q: str, limit: int = 5, x_api_key: str | None = Header(default=None)):
+async def search(
+    q: str,
+    limit: int = 5,
+    wing: str | None = None,
+    room: str | None = None,
+    x_api_key: str | None = Header(default=None),
+):
     _check_auth(x_api_key)
+    args: dict = {"query": q, "limit": limit}
+    if wing is not None:
+        args["wing"] = wing
+    if room is not None:
+        args["room"] = room
     result = await _call({
         "jsonrpc": "2.0", "id": 1,
         "method": "tools/call",
-        "params": {"name": "mempalace_search", "arguments": {"query": q, "limit": limit}},
+        "params": {"name": "mempalace_search", "arguments": args},
     })
     return _unwrap(result)
 
 
 @app.get("/context")
-async def context(topic: str, limit: int = 5, x_api_key: str | None = Header(default=None)):
+async def context(
+    topic: str,
+    limit: int = 5,
+    wing: str | None = None,
+    room: str | None = None,
+    x_api_key: str | None = Header(default=None),
+):
     # Alias for /search with a semantically friendlier name for LLM tool prompts
     _check_auth(x_api_key)
+    args: dict = {"query": topic, "limit": limit}
+    if wing is not None:
+        args["wing"] = wing
+    if room is not None:
+        args["room"] = room
     result = await _call({
         "jsonrpc": "2.0", "id": 1,
         "method": "tools/call",
-        "params": {"name": "mempalace_search", "arguments": {"query": topic, "limit": limit}},
+        "params": {"name": "mempalace_search", "arguments": args},
     })
     return _unwrap(result)
 

--- a/tests/test_search_wing_filter.py
+++ b/tests/test_search_wing_filter.py
@@ -1,0 +1,114 @@
+"""Tests for the /search and /context wing/room filter pass-through.
+
+Both endpoints accept optional ``wing`` and ``room`` query params. When
+supplied they are forwarded into ``mempalace_search``'s arguments;
+when omitted the endpoints behave exactly as before (back-compat).
+
+These invoke the endpoint coroutines directly with ``_call`` mocked so
+no live daemon, MCP child, or palace is required.
+
+Run with::
+
+    python -m unittest tests.test_search_wing_filter -v
+"""
+import os
+import sys
+import unittest
+from unittest.mock import patch, AsyncMock
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+import main  # noqa: E402
+
+
+class _SearchTestBase(unittest.IsolatedAsyncioTestCase):
+
+    async def asyncSetUp(self):
+        self._patches = [
+            patch.object(main, "_check_auth", side_effect=lambda *_a, **_k: None),
+            patch.object(main, "_unwrap", side_effect=lambda r: r),
+        ]
+        for p in self._patches:
+            p.start()
+
+    async def asyncTearDown(self):
+        for p in self._patches:
+            p.stop()
+
+    @staticmethod
+    def _captured_args(call_mock):
+        """Pull the ``arguments`` dict the endpoint forwarded into _call()."""
+        assert call_mock.call_count == 1, "expected exactly one MCP call"
+        req = call_mock.call_args.args[0]
+        return req["params"]["arguments"]
+
+
+class TestSearchWingFilter(_SearchTestBase):
+
+    async def test_search_no_filters_back_compat(self):
+        with patch.object(main, "_call", new=AsyncMock(return_value={})) as mock:
+            await main.search(q="hello", limit=5, x_api_key=None)
+        args = self._captured_args(mock)
+        self.assertEqual(args, {"query": "hello", "limit": 5})
+        self.assertNotIn("wing", args)
+        self.assertNotIn("room", args)
+
+    async def test_search_forwards_wing(self):
+        with patch.object(main, "_call", new=AsyncMock(return_value={})) as mock:
+            await main.search(q="hello", limit=5, wing="kit_projects", x_api_key=None)
+        args = self._captured_args(mock)
+        self.assertEqual(args["wing"], "kit_projects")
+        self.assertNotIn("room", args)
+
+    async def test_search_forwards_room(self):
+        with patch.object(main, "_call", new=AsyncMock(return_value={})) as mock:
+            await main.search(q="hello", limit=5, room="log", x_api_key=None)
+        args = self._captured_args(mock)
+        self.assertEqual(args["room"], "log")
+        self.assertNotIn("wing", args)
+
+    async def test_search_forwards_both(self):
+        with patch.object(main, "_call", new=AsyncMock(return_value={})) as mock:
+            await main.search(
+                q="hello", limit=3, wing="kit_projects", room="log", x_api_key=None,
+            )
+        args = self._captured_args(mock)
+        self.assertEqual(args, {
+            "query": "hello", "limit": 3,
+            "wing": "kit_projects", "room": "log",
+        })
+
+
+class TestContextWingFilter(_SearchTestBase):
+
+    async def test_context_no_filters_back_compat(self):
+        with patch.object(main, "_call", new=AsyncMock(return_value={})) as mock:
+            await main.context(topic="rfc-99", limit=5, x_api_key=None)
+        args = self._captured_args(mock)
+        self.assertEqual(args, {"query": "rfc-99", "limit": 5})
+        self.assertNotIn("wing", args)
+        self.assertNotIn("room", args)
+
+    async def test_context_forwards_wing(self):
+        with patch.object(main, "_call", new=AsyncMock(return_value={})) as mock:
+            await main.context(topic="rfc-99", limit=5, wing="kit_projects", x_api_key=None)
+        args = self._captured_args(mock)
+        self.assertEqual(args["wing"], "kit_projects")
+
+    async def test_context_forwards_both(self):
+        with patch.object(main, "_call", new=AsyncMock(return_value={})) as mock:
+            await main.context(
+                topic="rfc-99", limit=2, wing="kit_projects", room="log", x_api_key=None,
+            )
+        args = self._captured_args(mock)
+        self.assertEqual(args, {
+            "query": "rfc-99", "limit": 2,
+            "wing": "kit_projects", "room": "log",
+        })
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #43.

## Problem

`GET /search` and `GET /context` accept only `q`/`topic` and `limit`. They wrap `mempalace_search`, which itself supports `wing` and `room` filters as first-class arguments, but the daemon does not expose them — there is no way to scope a semantic search to a single wing or room over HTTP.

`/list` already accepts optional `wing` / `room` query parameters and forwards them into `mempalace_list_drawers` only when supplied. The pattern is established; `/search` and `/context` just need to mirror it.

## Change

- `/search` accepts optional `wing` and `room` query parameters.
- `/context` accepts the same.
- Both forward only when supplied. When omitted, behavior is byte-identical to before — existing clients are unaffected.

This unblocks any HTTP/MCP caller that wants per-wing semantic search without pulling everything and filtering client-side.

## Tests

Added `tests/test_search_wing_filter.py` — 7 unit tests covering back-compat, single-filter, and combined-filter cases for both endpoints. Mocks `_call`, so no live daemon or palace required.

Run with:

```bash
python -m unittest tests.test_search_wing_filter -v
```

All 11 tests in the suite pass (4 pre-existing + 7 new).

## Validation

Tested locally against a fresh palace in a Docker container on port 8086 (per the README's "Testing & Development" recipe), seeded with three drawers across two wings:

| Request | Expected | Got |
|---|---|---|
| `/search?q=fox` (no filter) | 3 hits across both wings | 3 ✅ |
| `/search?q=fox&wing=test_wing_a` | 2 hits, only wing_a | 2 ✅ |
| `/search?q=fox&wing=test_wing_b` | 1 hit, only wing_b | 1 ✅ |
| `/context?topic=fox&wing=test_wing_b` | 1 hit, only wing_b | 1 ✅ |
| `/search?q=fox&room=notes` | 3 hits, all in room=notes | 3 ✅ |
| `/search?q=fox&wing=missing` | 0 hits, no error | 0 ✅ |

mempalace's response envelope already echoes the applied filters back in a `"filters": {"wing": ..., "room": ...}` block, so clients can confirm which scope was actually applied without parsing the request URL — a small bonus that comes free with the change.

## CHANGELOG

Entry added under `[Unreleased]`.

---

Verified against `main` HEAD (`b5b4524` = v1.8.1, 2026-06-08).
